### PR TITLE
chore: update example urls

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Raccoon for Lemmy
-email: raccoonforlemmy@example.com
+email: livefast.eattrash.raccoon@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Raccoon for Lemmy 🦝 documentation
 baseurl: "/RaccoonForLemmy" # the subpath of your site, e.g. /blog

--- a/unit/about/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/about/AboutConstants.kt
+++ b/unit/about/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/about/AboutConstants.kt
@@ -2,12 +2,12 @@ package com.livefast.eattrash.raccoonforlemmy.unit.about
 
 internal object AboutConstants {
     const val REPORT_URL =
-        "https://example.com/"
+        "https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/issues/new?labels=bug"
     const val CHANGELOG_URL =
-        "https://example.com"
-    const val REPORT_EMAIL_ADDRESS = "raccoonforlemmy@example.com"
-    const val WEBSITE_URL = "https://example.com"
+        "https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/releases/latest"
+    const val REPORT_EMAIL_ADDRESS = "livefast.eattrash.raccoon@gmail.com"
+    const val WEBSITE_URL = "https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy"
     const val GOOGLE_PLAY_URL = "https://example.com"
-    const val LEMMY_COMMUNITY_NAME = "raccoonforlemmy"
+    const val LEMMY_COMMUNITY_NAME = "raccoonforlemmyapp"
     const val LEMMY_COMMUNITY_INSTANCE = "lemmy.world"
 }

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ContentPreview.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ContentPreview.kt
@@ -105,7 +105,7 @@ Ut enim ad minim veniam, quis *nostrud* exercitation ullamco laboris nisi ut ali
 velit esse cillum dolore eu fugiat nulla pariatur.
                 """.trimIndent(),
             thumbnailUrl = "https://feddit.it/pictrs/image/f677007a-166a-43b0-aea8-4c41ae1a35e8.webp?format=webp",
-            url = "https://example.com",
+            url = "https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy",
             publishDate = "2024-01-01T12:00:00Z",
             upvotes = 2,
             downvotes = 1,


### PR DESCRIPTION
Corrected example URLs from the project renaming.  

NOTE:  A few still remain: 
- `docs/config.yml`:  **26** -  _original github.io website_
- `feature/settings/[...]/feature/settings/main/SettingsScreen.kt`:  **428**  - _user manual on github.io_
- `unit/about/[...]/unit/about/AboutConstants.kt`:  **10**  - _Google Play url_