### PR TITLE
chore: update deps

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -1,4 +1,6 @@
+import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -51,9 +53,15 @@ kotlin {
 
 android {
     namespace = "com.livefast.eattrash.raccoonforlemmy.core.api"
-    compileSdk = libs.versions.android.targetSdk.get().toInt()
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
     defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
     }
 }
 
@@ -63,4 +71,12 @@ dependencies {
     add("kspIosX64", libs.ktorfit.ksp)
     add("kspIosArm64", libs.ktorfit.ksp)
     add("kspIosSimulatorArm64", libs.ktorfit.ksp)
+}
+
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType<KotlinCompile> {
+    dependsOn(tasks.withType<KspTaskMetadata>())
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
@@ -9,6 +9,15 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.service.PrivateMessageServ
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.SearchService
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.SiteService
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.UserService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createAuthService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createCommentService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createCommunityService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createModlogService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createPostService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createPrivateMessageService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createSearchService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createSiteService
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.createUserService
 import com.livefast.eattrash.raccoonforlemmy.core.utils.network.provideHttpClientEngineFactory
 import de.jensklingenberg.ktorfit.Ktorfit
 import io.ktor.client.HttpClient
@@ -31,34 +40,24 @@ internal class DefaultServiceProvider(
     }
 
     override var currentInstance: String = DEFAULT_INSTANCE
-        private set
 
     override lateinit var auth: AuthService
-        private set
 
     override lateinit var post: PostService
-        private set
 
     override lateinit var community: CommunityService
-        private set
 
     override lateinit var user: UserService
-        private set
 
     override lateinit var site: SiteService
-        private set
 
     override lateinit var comment: CommentService
-        private set
 
     override lateinit var search: SearchService
-        private set
 
     override lateinit var privateMessages: PrivateMessageService
-        private set
 
     override lateinit var modLog: ModlogService
-        private set
 
     private val baseUrl: String get() = "https://$currentInstance/api/$VERSION/"
 
@@ -107,15 +106,14 @@ internal class DefaultServiceProvider(
                 .baseUrl(baseUrl)
                 .httpClient(client)
                 .build()
-        auth = ktorfit.create()
-        post = ktorfit.create()
-        community = ktorfit.create()
-        user = ktorfit.create()
-        site = ktorfit.create()
-        comment = ktorfit.create()
-        search = ktorfit.create()
-        privateMessages = ktorfit.create()
-        privateMessages = ktorfit.create()
-        modLog = ktorfit.create()
+        auth = ktorfit.createAuthService()
+        post = ktorfit.createPostService()
+        community = ktorfit.createCommunityService()
+        user = ktorfit.createUserService()
+        site = ktorfit.createSiteService()
+        comment = ktorfit.createCommentService()
+        search = ktorfit.createSearchService()
+        privateMessages = ktorfit.createPrivateMessageService()
+        modLog = ktorfit.createModlogService()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,22 +4,23 @@ androidx-activity = "1.9.1"
 androidx-browser = "1.8.0"
 androidx-core = "1.13.1"
 androidx-crypto = "1.0.0"
-androidx-media3 = "1.4.0"
+androidx-media3 = "1.4.1"
 androidx-splashscreen = "1.0.1"
-androidx-work = "2.9.0"
-android-gradle = "8.5.1"
+androidx-work = "2.9.1"
+android-gradle = "8.5.2"
 coil = "2.7.0"
 compose = "1.6.11"
 detekt = "1.23.6"
 kamel = "0.9.5"
 koin = "3.5.6"
-kotlin = "2.0.0"
+kotlin = "2.0.20"
 kotlincrypto = "0.5.1"
 kotlinx-coroutines = "1.8.1"
 kotlinx-serialization-json = "1.7.1"
-ksp = "2.0.0-1.0.23"
+ksp = "2.0.20-1.0.24"
 ktor = "2.3.12"
-ktorfit = "2.0.0-rc01"
+ktorfit = "2.0.1"
+ktorfit-ksp = "2.0.1-1.0.24"
 lyricist = "1.7.0"
 materialKolor = "1.7.0"
 mockk = "1.13.12"
@@ -73,7 +74,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit" }
+ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit-ksp" }
 ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
 
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }


### PR DESCRIPTION
This PR updates a series of dependencies to the latest versions:
- androidx-media3 from 1.4.0 to 1.4.1
- androidx-work from 2.9.0 to 2.9.1
- AGP from 8.5.1 to 8.5.2
- Kotlin from 2.0.0 to 2.0.20
- KSP from 2.0.0-1.0.23 to 2.0.20-1.0.24
- Ktorfit from 2.0.0-rc01 to 2.0.1

The latter one required some adaptation since Ktorfit 2.0.1 is not backwards compatible with the previous RC, especially in that they deprecated the old generic `<T> fun create(): T` factory method to create service instances and rely on a series of autogenerated extension functions, each of which specific for a single service.