### PR TITLE
refactor: use composition locals to provide a `UriHandler` implementation

### DIFF
--- a/core/commonui/detailopener-api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
+++ b/core/commonui/detailopener-api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/detailopener/api/DetailOpener.kt
@@ -44,4 +44,6 @@ interface DetailOpener {
         initialNsfw: Boolean? = null,
         forceCommunitySelection: Boolean = false,
     )
+
+    fun openWebInternal(url: String)
 }

--- a/core/commonui/detailopener-impl/build.gradle.kts
+++ b/core/commonui/detailopener-impl/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
                 implementation(projects.unit.userdetail)
                 implementation(projects.unit.createpost)
                 implementation(projects.unit.createcomment)
+                implementation(projects.unit.web)
             }
         }
         val androidUnitTest by getting {
@@ -70,8 +71,14 @@ kotlin {
 
 android {
     namespace = "com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.impl"
-    compileSdk = libs.versions.android.targetSdk.get().toInt()
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
     defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
     }
 }

--- a/core/commonui/detailopener-impl/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
+++ b/core/commonui/detailopener-impl/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/detailopener/impl/DefaultDetailOpener.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforlemmy.unit.createcomment.CreateCommentScr
 import com.livefast.eattrash.raccoonforlemmy.unit.createpost.CreatePostScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.postdetail.PostDetailScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.userdetail.UserDetailScreen
+import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -200,5 +201,10 @@ class DefaultDetailOpener(
 
         // start recursive search
         return searchRec()
+    }
+
+    override fun openWebInternal(url: String) {
+        val screen = WebViewScreen(url)
+        navigationCoordinator.pushScreen(screen)
     }
 }

--- a/core/commonui/lemmyui/build.gradle.kts
+++ b/core/commonui/lemmyui/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.lemmy.data)
+                implementation(projects.core.commonui.detailopenerApi)
             }
         }
         val commonTest by getting {

--- a/core/commonui/lemmyui/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
+++ b/core/commonui/lemmyui/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
@@ -1,9 +1,20 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di
 
+import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.CustomUriHandler
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.FabNestedScrollConnection
+import org.koin.core.parameter.parametersOf
 import org.koin.java.KoinJavaComponent
 
 actual fun getFabNestedScrollConnection(): FabNestedScrollConnection {
     val res: FabNestedScrollConnection by KoinJavaComponent.inject(FabNestedScrollConnection::class.java)
+    return res
+}
+
+actual fun getCustomUriHandler(fallbackUriHandler: UriHandler): CustomUriHandler {
+    val res: CustomUriHandler by KoinJavaComponent.inject(
+        clazz = CustomUriHandler::class.java,
+        parameters = { parametersOf(fallbackUriHandler) },
+    )
     return res
 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
@@ -43,7 +43,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.utils.texttoolbar.getCustomTex
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 
 private val BAR_BASE_WIDTH_UNIT = 1.25.dp
@@ -79,8 +78,6 @@ fun CommentCard(
     onReply: (() -> Unit)? = null,
     onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
     onOpenCreator: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
     onToggleExpanded: (() -> Unit)? = null,
 ) {
@@ -219,10 +216,6 @@ fun CommentCard(
                                     highlightText = highlightText,
                                     onOpenImage = onImageClick,
                                     onDoubleClick = onDoubleClick,
-                                    onOpenCommunity = onOpenCommunity,
-                                    onOpenUser = onOpenCreator,
-                                    onOpenPost = onOpenPost,
-                                    onOpenWeb = onOpenWeb,
                                     onLongClick = {
                                         textSelection = true
                                     },

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CustomUriHandler.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CustomUriHandler.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di.getCustomUriHandler
+
+@Stable
+interface CustomUriHandler : UriHandler
+
+@Composable
+fun ProvideCustomUriHandler(content: @Composable () -> Unit) {
+    val fallbackHandler = LocalUriHandler.current
+    val customUriHandler = remember { getCustomUriHandler(fallbackHandler) }
+    CompositionLocalProvider(
+        value = LocalUriHandler provides customUriHandler,
+        content = content,
+    )
+}

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/DefaultCustomUriHandler.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/DefaultCustomUriHandler.kt
@@ -1,0 +1,59 @@
+package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
+
+import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.api.DetailOpener
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAVideo
+import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAnImage
+import com.livefast.eattrash.raccoonforlemmy.core.utils.url.CustomTabsHelper
+import com.livefast.eattrash.raccoonforlemmy.core.utils.url.UrlOpeningMode
+import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
+
+internal class DefaultCustomUriHandler(
+    private val fallbackHandler: UriHandler,
+    private val settingsRepository: SettingsRepository,
+    private val detailOpener: DetailOpener,
+    private val customTabsHelper: CustomTabsHelper,
+) : CustomUriHandler {
+    override fun openUri(uri: String) {
+        val community = getCommunityFromUrl(uri)
+        val user = getUserFromUrl(uri)
+        val (post, postInstance) = getPostFromUrl(uri) ?: (null to null)
+        val isMedia = uri.looksLikeAVideo || uri.looksLikeAnImage
+        val openingMode =
+            settingsRepository.currentSettings.value.urlOpeningMode
+                .toUrlOpeningMode()
+
+        when {
+            community != null && !isMedia -> {
+                detailOpener.openCommunityDetail(community, community.host)
+            }
+
+            user != null && !isMedia -> {
+                detailOpener.openUserDetail(user, user.host)
+            }
+
+            post != null && !isMedia -> {
+                detailOpener.openPostDetail(post, postInstance.orEmpty())
+            }
+
+            openingMode == UrlOpeningMode.Internal -> {
+                detailOpener.openWebInternal(uri)
+            }
+
+            openingMode == UrlOpeningMode.CustomTabs -> {
+                runCatching {
+                    customTabsHelper.handle(uri)
+                }.also {
+                    it.exceptionOrNull()?.also { e ->
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+            else -> {
+                fallbackHandler.openUri(uri)
+            }
+        }
+    }
+}

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
@@ -164,9 +164,6 @@ fun InboxCard(
                                     onClickPost.invoke()
                                 }
                             },
-                            onOpenUser = { user, instance ->
-                                onOpenCreator(user, instance)
-                            },
                             onLongClick = {
                                 textSelection = true
                             },

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -45,15 +45,12 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomizedContent
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAnImage
 import com.livefast.eattrash.raccoonforlemmy.core.utils.share.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.texttoolbar.getCustomTextToolbar
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
@@ -84,8 +81,6 @@ fun PostCard(
     options: List<Option> = emptyList(),
     onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
     onOpenCreator: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
     onUpVote: (() -> Unit)? = null,
     onDownVote: (() -> Unit)? = null,
     onSave: (() -> Unit)? = null,
@@ -145,8 +140,6 @@ fun PostCard(
                 options = options,
                 onOpenCommunity = onOpenCommunity,
                 onOpenCreator = onOpenCreator,
-                onOpenPost = onOpenPost,
-                onOpenWeb = onOpenWeb,
                 onUpVote = onUpVote,
                 onDownVote = onDownVote,
                 onSave = onSave,
@@ -175,8 +168,6 @@ fun PostCard(
                 options = options,
                 onOpenCommunity = onOpenCommunity,
                 onOpenCreator = onOpenCreator,
-                onOpenPost = onOpenPost,
-                onOpenWeb = onOpenWeb,
                 onUpVote = onUpVote,
                 onDownVote = onDownVote,
                 onSave = onSave,
@@ -210,8 +201,6 @@ private fun CompactPost(
     options: List<Option>,
     onOpenCommunity: ((CommunityModel, String) -> Unit)?,
     onOpenCreator: ((UserModel, String) -> Unit)?,
-    onOpenPost: ((PostModel, String) -> Unit)?,
-    onOpenWeb: ((String) -> Unit)?,
     onUpVote: (() -> Unit)?,
     onDownVote: (() -> Unit)?,
     onSave: (() -> Unit)?,
@@ -224,8 +213,6 @@ private fun CompactPost(
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
     val uriHandler = LocalUriHandler.current
-    val customTabsHelper = remember { getCustomTabsHelper() }
-    val navigationCoordinator = remember { getNavigationCoordinator() }
     var textSelection by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
     val postLinkUrl =
@@ -315,12 +302,8 @@ private fun CompactPost(
                                     onClick?.invoke()
                                 }
                             },
-                            onOpenCommunity = onOpenCommunity,
-                            onOpenUser = onOpenCreator,
-                            onOpenPost = onOpenPost,
                             onOpenImage = onOpenImage,
                             onDoubleClick = onDoubleClick,
-                            onOpenWeb = onOpenWeb,
                             onLongClick = {
                                 textSelection = true
                             },
@@ -338,16 +321,7 @@ private fun CompactPost(
                             autoLoadImages = autoLoadImages,
                             onOpen = {
                                 if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
-                                    navigationCoordinator.handleUrl(
-                                        url = postLinkUrl,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = onOpenWeb,
-                                        onOpenCommunity = onOpenCommunity,
-                                        onOpenPost = onOpenPost,
-                                        onOpenUser = onOpenCreator,
-                                    )
+                                    uriHandler.openUri(postLinkUrl)
                                 } else {
                                     onClick?.invoke()
                                 }
@@ -379,16 +353,7 @@ private fun CompactPost(
                             blurred = blurNsfw && post.nsfw,
                             onImageClick = { url ->
                                 if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
-                                    navigationCoordinator.handleUrl(
-                                        url = postLinkUrl,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = onOpenWeb,
-                                        onOpenCommunity = onOpenCommunity,
-                                        onOpenPost = onOpenPost,
-                                        onOpenUser = onOpenCreator,
-                                    )
+                                    uriHandler.openUri(postLinkUrl)
                                 } else {
                                     onOpenImage?.invoke(url)
                                 }
@@ -460,8 +425,6 @@ private fun ExtendedPost(
     options: List<Option>,
     onOpenCommunity: ((CommunityModel, String) -> Unit)?,
     onOpenCreator: ((UserModel, String) -> Unit)?,
-    onOpenPost: ((PostModel, String) -> Unit)?,
-    onOpenWeb: ((String) -> Unit)?,
     onUpVote: (() -> Unit)?,
     onDownVote: (() -> Unit)?,
     onSave: (() -> Unit)?,
@@ -474,8 +437,6 @@ private fun ExtendedPost(
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
     val uriHandler = LocalUriHandler.current
-    val customTabsHelper = remember { getCustomTabsHelper() }
-    val navigationCoordinator = remember { getNavigationCoordinator() }
     var textSelection by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
     val postLinkUrl =
@@ -564,10 +525,6 @@ private fun ExtendedPost(
                         highlightText = highlightText,
                         bolder = showBody,
                         autoLoadImages = autoLoadImages,
-                        onOpenCommunity = onOpenCommunity,
-                        onOpenUser = onOpenCreator,
-                        onOpenPost = onOpenPost,
-                        onOpenWeb = onOpenWeb,
                         onClick = {
                             if (textSelection) {
                                 focusManager.clearFocus(true)
@@ -598,16 +555,7 @@ private fun ExtendedPost(
                         backgroundColor = backgroundColor,
                         onOpen = {
                             if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
-                                navigationCoordinator.handleUrl(
-                                    url = postLinkUrl,
-                                    openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                    uriHandler = uriHandler,
-                                    customTabsHelper = customTabsHelper,
-                                    onOpenWeb = onOpenWeb,
-                                    onOpenCommunity = onOpenCommunity,
-                                    onOpenPost = onOpenPost,
-                                    onOpenUser = onOpenCreator,
-                                )
+                                uriHandler.openUri(postLinkUrl)
                             } else {
                                 onClick?.invoke()
                             }
@@ -637,16 +585,7 @@ private fun ExtendedPost(
                         blurred = blurNsfw && post.nsfw,
                         onImageClick = { url ->
                             if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
-                                navigationCoordinator.handleUrl(
-                                    url = postLinkUrl,
-                                    openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                    uriHandler = uriHandler,
-                                    customTabsHelper = customTabsHelper,
-                                    onOpenWeb = onOpenWeb,
-                                    onOpenCommunity = onOpenCommunity,
-                                    onOpenPost = onOpenPost,
-                                    onOpenUser = onOpenCreator,
-                                )
+                                uriHandler.openUri(postLinkUrl)
                             } else {
                                 onOpenImage?.invoke(url)
                             }
@@ -689,11 +628,7 @@ private fun ExtendedPost(
                                         onClick?.invoke()
                                     }
                                 },
-                                onOpenCommunity = onOpenCommunity,
-                                onOpenUser = onOpenCreator,
-                                onOpenPost = onOpenPost,
                                 onOpenImage = onOpenImage,
-                                onOpenWeb = onOpenWeb,
                                 onDoubleClick = onDoubleClick,
                                 onLongClick = {
                                     textSelection = true
@@ -714,16 +649,7 @@ private fun ExtendedPost(
                                 ),
                         url = postLinkUrl,
                         onClick = {
-                            navigationCoordinator.handleUrl(
-                                url = postLinkUrl,
-                                openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                uriHandler = uriHandler,
-                                customTabsHelper = customTabsHelper,
-                                onOpenWeb = onOpenWeb,
-                                onOpenCommunity = onOpenCommunity,
-                                onOpenPost = onOpenPost,
-                                onOpenUser = onOpenCreator,
-                            )
+                            uriHandler.openUri(postLinkUrl)
                         },
                     )
                 }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
@@ -16,13 +16,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.readContentAlpha
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toTypography
 import com.livefast.eattrash.raccoonforlemmy.core.markdown.CustomMarkdownWrapperController
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import kotlinx.coroutines.flow.map
@@ -40,14 +34,8 @@ fun PostCardBody(
     onOpenImage: ((String) -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
-    onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
-    onOpenUser: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
-    val customTabsHelper = remember { getCustomTabsHelper() }
-    val navigationCoordinator = remember { getNavigationCoordinator() }
     val settingsRepository = remember { getSettingsRepository() }
     val themeRepository = remember { getThemeRepository() }
     val fontFamily by themeRepository.contentFontFamily.collectAsState()
@@ -92,18 +80,7 @@ fun PostCardBody(
                 enableAlternateRendering = enableAlternateMarkdownRendering,
                 blurImages = blurImages,
                 onOpenUrl = { url ->
-                    navigationCoordinator.handleUrl(
-                        url = url,
-                        openingMode =
-                            settingsRepository.currentSettings.value.urlOpeningMode
-                                .toUrlOpeningMode(),
-                        uriHandler = uriHandler,
-                        customTabsHelper = customTabsHelper,
-                        onOpenCommunity = onOpenCommunity,
-                        onOpenUser = onOpenUser,
-                        onOpenPost = onOpenPost,
-                        onOpenWeb = onOpenWeb,
-                    )
+                    uriHandler.openUri(url)
                 },
                 onOpenImage = { url ->
                     onOpenImage?.invoke(url)

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
@@ -17,13 +17,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.readContentAlpha
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toTypography
 import com.livefast.eattrash.raccoonforlemmy.core.markdown.CustomMarkdownWrapper
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import kotlinx.coroutines.flow.map
@@ -40,14 +34,8 @@ fun PostCardTitle(
     onOpenImage: ((String) -> Unit)? = null,
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
-    onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
-    onOpenUser: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
 ) {
     val uriHandler = LocalUriHandler.current
-    val customTabsHelper = remember { getCustomTabsHelper() }
-    val navigationCoordinator = remember { getNavigationCoordinator() }
     val settingsRepository = remember { getSettingsRepository() }
     val themeRepository = remember { getThemeRepository() }
     val fontFamily by themeRepository.contentFontFamily.collectAsState()
@@ -100,18 +88,7 @@ fun PostCardTitle(
             highlightText = highlightText,
             enableAlternateRendering = enableAlternateMarkdownRendering,
             onOpenUrl = { url ->
-                navigationCoordinator.handleUrl(
-                    url = url,
-                    openingMode =
-                        settingsRepository.currentSettings.value.urlOpeningMode
-                            .toUrlOpeningMode(),
-                    uriHandler = uriHandler,
-                    customTabsHelper = customTabsHelper,
-                    onOpenCommunity = onOpenCommunity,
-                    onOpenUser = onOpenUser,
-                    onOpenPost = onOpenPost,
-                    onOpenWeb = onOpenWeb,
-                )
+                uriHandler.openUri(url)
             },
             onOpenImage = { url ->
                 onOpenImage?.invoke(url)

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/UrlUtils.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/UrlUtils.kt
@@ -1,11 +1,5 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
 
-import androidx.compose.ui.platform.UriHandler
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.NavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAVideo
-import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAnImage
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.CustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.UrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
@@ -37,56 +31,6 @@ fun getPostFromUrl(url: String?): Pair<PostModel, String>? {
         post to instance
     } else {
         null
-    }
-}
-
-fun NavigationCoordinator.handleUrl(
-    url: String,
-    openingMode: UrlOpeningMode,
-    uriHandler: UriHandler,
-    customTabsHelper: CustomTabsHelper,
-    onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
-    onOpenUser: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
-) {
-    val community = getCommunityFromUrl(url)
-    val user = getUserFromUrl(url)
-    val (post, postInstance) = getPostFromUrl(url) ?: (null to null)
-    val isMedia = url.looksLikeAVideo || url.looksLikeAnImage
-
-    when {
-        community != null && !isMedia && onOpenCommunity != null -> {
-            onOpenCommunity.invoke(community, community.host)
-        }
-
-        user != null && !isMedia && onOpenUser != null -> {
-            onOpenUser.invoke(user, user.host)
-        }
-
-        post != null && !isMedia && onOpenPost != null -> {
-            onOpenPost.invoke(post, postInstance.orEmpty())
-        }
-
-        openingMode == UrlOpeningMode.External -> {
-            runCatching {
-                uriHandler.openUri(url)
-            }
-        }
-
-        openingMode == UrlOpeningMode.CustomTabs -> {
-            runCatching {
-                customTabsHelper.handle(url)
-            }.also {
-                it.exceptionOrNull()?.also { e ->
-                    e.printStackTrace()
-                }
-            }
-        }
-
-        else -> {
-            onOpenWeb?.invoke(url)
-        }
     }
 }
 
@@ -186,7 +130,8 @@ private fun extractPost(url: String): PostModel? {
     val match = regex.find(url)
     val id =
         match
-            ?.let { it.groups["postId"]?.value.orEmpty() }?.toLongOrNull()
+            ?.let { it.groups["postId"]?.value.orEmpty() }
+            ?.toLongOrNull()
     return if (id != null) {
         PostModel(id = id)
     } else {

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/LemmyUiModule.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/LemmyUiModule.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di
 
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.CustomUriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.DefaultCustomUriHandler
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.DefaultFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.FabNestedScrollConnection
 import org.koin.dsl.module
@@ -8,5 +10,13 @@ val lemmyUiModule =
     module {
         factory<FabNestedScrollConnection> {
             DefaultFabNestedScrollConnection()
+        }
+        single<CustomUriHandler> { params ->
+            DefaultCustomUriHandler(
+                fallbackHandler = params[0],
+                settingsRepository = get(),
+                detailOpener = get(),
+                customTabsHelper = get(),
+            )
         }
     }

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
@@ -1,5 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di
 
+import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.CustomUriHandler
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.FabNestedScrollConnection
 
 expect fun getFabNestedScrollConnection(): FabNestedScrollConnection
+
+expect fun getCustomUriHandler(fallbackUriHandler: UriHandler): CustomUriHandler

--- a/core/commonui/lemmyui/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
+++ b/core/commonui/lemmyui/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/di/Utils.kt
@@ -1,11 +1,23 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di
 
+import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.CustomUriHandler
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.FabNestedScrollConnection
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.koin.core.parameter.parametersOf
 
 actual fun getFabNestedScrollConnection(): FabNestedScrollConnection = LemmyUiDiHelper.fabNestedScrollConnection
 
+actual fun getCustomUriHandler(fallbackUriHandler: UriHandler): CustomUriHandler = LemmyUiDiHelper.getCustomUriHandler(fallbackUriHandler)
+
 object LemmyUiDiHelper : KoinComponent {
     val fabNestedScrollConnection: FabNestedScrollConnection by inject()
+
+    fun getCustomUriHandler(fallbackUriHandler: UriHandler): CustomUriHandler {
+        val res by inject<CustomUriHandler>(
+            parameters = { parametersOf(fallbackUriHandler) },
+        )
+        return res
+    }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -139,12 +139,14 @@ internal class DefaultNavigationCoordinator(
     }
 
     override fun showBottomSheet(screen: Screen) {
+        closeSideMenu()
         scope.launch {
             bottomSheetChannel.send(NavigationEvent.Show(screen))
         }
     }
 
     override fun pushScreen(screen: Screen) {
+        closeSideMenu()
         scope.launch {
             screenChannel.send(NavigationEvent.Show(screen))
         }
@@ -172,16 +174,20 @@ internal class DefaultNavigationCoordinator(
     }
 
     override fun openSideMenu(screen: Screen) {
-        scope.launch {
-            sideMenuEvents.emit(SideMenuEvents.Open(screen))
-            sideMenuOpened.value = true
+        if (!sideMenuOpened.value) {
+            scope.launch {
+                sideMenuEvents.emit(SideMenuEvents.Open(screen))
+                sideMenuOpened.value = true
+            }
         }
     }
 
     override fun closeSideMenu() {
-        scope.launch {
-            sideMenuEvents.emit(SideMenuEvents.Close)
-            sideMenuOpened.value = false
+        if (sideMenuOpened.value) {
+            scope.launch {
+                sideMenuEvents.emit(SideMenuEvents.Close)
+                sideMenuOpened.value = false
+            }
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -113,8 +113,6 @@ internal object ProfileMainScreen : Tab {
             notificationCenter
                 .subscribe(NotificationCenterEvent.ProfileSideMenuAction::class)
                 .onEach { evt ->
-                    navigationCoordinator.closeSideMenu()
-
                     when (evt) {
                         NotificationCenterEvent.ProfileSideMenuAction.ManageAccounts -> {
                             navigationCoordinator.showBottomSheet(ManageAccountsScreen())

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -45,7 +45,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsHeader
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.LanguageBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.ListingTypeBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SortBottomSheet
@@ -58,7 +57,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificati
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLanguageFlag
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLanguageName
 import com.livefast.eattrash.raccoonforlemmy.core.utils.url.UrlOpeningMode
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toReadableName
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toReadableName
@@ -73,7 +71,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.filteredcontents.FilteredConte
 import com.livefast.eattrash.raccoonforlemmy.unit.filteredcontents.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.manageban.ManageBanScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.medialist.MediaListScreen
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -93,7 +90,6 @@ class SettingsScreen : Screen {
         var infoDialogOpened by remember { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
         val uriHandler = LocalUriHandler.current
-        val customTabsHelper = remember { getCustomTabsHelper() }
 
         LaunchedEffect(notificationCenter) {
             notificationCenter
@@ -399,15 +395,7 @@ class SettingsScreen : Screen {
                         value = "",
                         disclosureIndicator = true,
                         onTap = {
-                            navigationCoordinator.handleUrl(
-                                url = "https://example.com",
-                                openingMode = uiState.urlOpeningMode,
-                                uriHandler = uriHandler,
-                                customTabsHelper = customTabsHelper,
-                                onOpenWeb = { url ->
-                                    navigationCoordinator.pushScreen(WebViewScreen(url))
-                                },
-                            )
+                            uriHandler.openUri("https://example.com")
                         },
                     )
 

--- a/unit/about/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/about/AboutDialog.kt
+++ b/unit/about/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/about/AboutDialog.kt
@@ -33,20 +33,15 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.resources.di.getCoreResources
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.livefast.eattrash.raccoonforlemmy.unit.about.components.AboutItem
 import com.livefast.eattrash.raccoonforlemmy.unit.acknowledgements.AcknowledgementsScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.licences.LicencesScreen
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 
 class AboutDialog : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -54,10 +49,7 @@ class AboutDialog : Screen {
     override fun Content() {
         val viewModel = getScreenModel<AboutDialogMviModel>()
         val uriHandler = LocalUriHandler.current
-        val customTabsHelper = remember { getCustomTabsHelper() }
         val navigationCoordinator = remember { getNavigationCoordinator() }
-        val settingsRepository = remember { getSettingsRepository() }
-        val settings by settingsRepository.currentSettings.collectAsState()
         val uiState by viewModel.uiState.collectAsState()
         val notificationCenter = remember { getNotificationCenter() }
         val detailOpener = remember { getDetailOpener() }
@@ -101,30 +93,14 @@ class AboutDialog : Screen {
                                 vector = Icons.Default.OpenInBrowser,
                                 textDecoration = TextDecoration.Underline,
                                 onClick = {
-                                    navigationCoordinator.handleUrl(
-                                        url = AboutConstants.CHANGELOG_URL,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
-                                    )
+                                    uriHandler.openUri(AboutConstants.CHANGELOG_URL)
                                 },
                             )
                         }
                         item {
                             Button(
                                 onClick = {
-                                    navigationCoordinator.handleUrl(
-                                        url = AboutConstants.REPORT_URL,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
-                                    )
+                                    uriHandler.openUri(AboutConstants.REPORT_URL)
                                 },
                             ) {
                                 Text(
@@ -153,15 +129,7 @@ class AboutDialog : Screen {
                                 text = LocalStrings.current.settingsAboutViewGithub,
                                 textDecoration = TextDecoration.Underline,
                                 onClick = {
-                                    navigationCoordinator.handleUrl(
-                                        url = AboutConstants.WEBSITE_URL,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
-                                    )
+                                    uriHandler.openUri(AboutConstants.WEBSITE_URL)
                                 },
                             )
                         }
@@ -171,15 +139,7 @@ class AboutDialog : Screen {
                                 text = LocalStrings.current.settingsAboutViewGooglePlay,
                                 textDecoration = TextDecoration.Underline,
                                 onClick = {
-                                    navigationCoordinator.handleUrl(
-                                        url = AboutConstants.GOOGLE_PLAY_URL,
-                                        openingMode = settings.urlOpeningMode.toUrlOpeningMode(),
-                                        uriHandler = uriHandler,
-                                        customTabsHelper = customTabsHelper,
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
-                                    )
+                                    uriHandler.openUri(AboutConstants.GOOGLE_PLAY_URL)
                                 },
                             )
                         }

--- a/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/AcknowledgementsScreen.kt
+++ b/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/AcknowledgementsScreen.kt
@@ -37,16 +37,11 @@ import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.unit.acknowledgements.components.AcknoledgementItem
 import com.livefast.eattrash.raccoonforlemmy.unit.acknowledgements.components.AcknoledgementItemPlaceholder
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 
 class AcknowledgementsScreen : Screen {
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
@@ -57,9 +52,7 @@ class AcknowledgementsScreen : Screen {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val settingsRepository = remember { getSettingsRepository() }
         val uriHandler = LocalUriHandler.current
-        val customTabsHelper = remember { getCustomTabsHelper() }
 
         Scaffold(
             modifier =
@@ -127,19 +120,7 @@ class AcknowledgementsScreen : Screen {
                                     .onClick(
                                         onClick = {
                                             if (!item.url.isNullOrEmpty()) {
-                                                navigationCoordinator.handleUrl(
-                                                    url = item.url,
-                                                    openingMode =
-                                                        settingsRepository.currentSettings.value.urlOpeningMode
-                                                            .toUrlOpeningMode(),
-                                                    uriHandler = uriHandler,
-                                                    customTabsHelper = customTabsHelper,
-                                                    onOpenWeb = { url ->
-                                                        navigationCoordinator.pushScreen(
-                                                            WebViewScreen(url),
-                                                        )
-                                                    },
-                                                )
+                                                uriHandler.openUri(item.url)
                                             }
                                         },
                                     ),

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -62,7 +62,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toTypography
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomImage
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.TextFormattingBar
@@ -75,7 +74,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.livefast.eattrash.raccoonforlemmy.unit.chat.components.MessageCard
 import com.livefast.eattrash.raccoonforlemmy.unit.chat.components.MessageCardPlaceholder
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -102,7 +100,6 @@ class InboxChatScreen(
         val typography = contentFontFamily.toTypography()
         var rawContent by remember { mutableStateOf<Any?>(null) }
         val lazyListState = rememberLazyListState()
-        val detailOpener = remember { getDetailOpener() }
         var itemIdToDelete by remember { mutableStateOf<Long?>(null) }
         val focusRequester = remember { FocusRequester() }
 
@@ -297,29 +294,6 @@ class InboxChatScreen(
                                             url = url,
                                             source = message.creator?.readableHandle.orEmpty(),
                                         ),
-                                    )
-                                },
-                                onOpenCommunity = { community, instance ->
-                                    detailOpener.openCommunityDetail(
-                                        community = community,
-                                        otherInstance = instance,
-                                    )
-                                },
-                                onOpenUser = { user, instance ->
-                                    detailOpener.openUserDetail(
-                                        user = user,
-                                        otherInstance = instance,
-                                    )
-                                },
-                                onOpenPost = { post, instance ->
-                                    detailOpener.openPostDetail(
-                                        post = post,
-                                        otherInstance = instance,
-                                    )
-                                },
-                                onOpenWeb = { url ->
-                                    navigationCoordinator.pushScreen(
-                                        WebViewScreen(url),
                                     )
                                 },
                                 options =

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/components/MessageCard.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/components/MessageCard.kt
@@ -42,12 +42,8 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.Customized
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.PostCardBody
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.datetime.prettifyDate
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 
 @Composable
 internal fun MessageCard(
@@ -55,10 +51,6 @@ internal fun MessageCard(
     isMyMessage: Boolean = false,
     content: String = "",
     date: String = "",
-    onOpenCommunity: ((CommunityModel, String) -> Unit)? = null,
-    onOpenUser: ((UserModel, String) -> Unit)? = null,
-    onOpenPost: ((PostModel, String) -> Unit)? = null,
-    onOpenWeb: ((String) -> Unit)? = null,
     onOpenImage: ((String) -> Unit)? = null,
     options: List<Option> = emptyList(),
     onOptionSelected: ((OptionId) -> Unit)? = null,
@@ -140,10 +132,6 @@ internal fun MessageCard(
                     PostCardBody(
                         text = content,
                         onOpenImage = onOpenImage,
-                        onOpenCommunity = onOpenCommunity,
-                        onOpenUser = onOpenUser,
-                        onOpenPost = onOpenPost,
-                        onOpenWeb = onOpenWeb,
                     )
                     Box {
                         Row(

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -134,7 +134,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.modlog.ModlogScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
 import com.livefast.eattrash.raccoonforlemmy.unit.reportlist.ReportListScreen
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -1024,14 +1023,6 @@ class CommunityDetailScreen(
                                                 }.takeIf { uiState.doubleTapActionEnabled && uiState.isLogged && !isOnOtherInstance },
                                             onOpenCreator = { user, instance ->
                                                 detailOpener.openUserDetail(user, instance)
-                                            },
-                                            onOpenPost = { p, instance ->
-                                                detailOpener.openPostDetail(p, instance)
-                                            },
-                                            onOpenWeb = { url ->
-                                                navigationCoordinator.pushScreen(
-                                                    WebViewScreen(url),
-                                                )
                                             },
                                             onUpVote =
                                                 {

--- a/unit/communityinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
+++ b/unit/communityinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -50,10 +49,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.utils.getPrettyNumber
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableName
 import com.livefast.eattrash.raccoonforlemmy.unit.communityinfo.components.ModeratorCell
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.koin.core.parameter.parametersOf
 
 class CommunityInfoScreen(
@@ -71,7 +67,6 @@ class CommunityInfoScreen(
             )
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
-        val scope = rememberCoroutineScope()
         val detailOpener = remember { getDetailOpener() }
 
         Scaffold(
@@ -222,11 +217,7 @@ class CommunityInfoScreen(
                                     autoLoadImages = uiState.autoLoadImages,
                                     user = user,
                                     onOpenUser = { _ ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            detailOpener.openUserDetail(user, "")
-                                        }
+                                        detailOpener.openUserDetail(user, "")
                                     },
                                 )
                             }
@@ -239,44 +230,12 @@ class CommunityInfoScreen(
                             modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
                             text = uiState.community.description,
                             onOpenImage = { url ->
-                                navigationCoordinator.closeSideMenu()
-                                scope.launch {
-                                    delay(100)
-                                    navigationCoordinator.pushScreen(
-                                        ZoomableImageScreen(
-                                            url = url,
-                                            source = uiState.community.readableHandle,
-                                        ),
-                                    )
-                                }
-                            },
-                            onOpenCommunity = { community, instance ->
-                                navigationCoordinator.closeSideMenu()
-                                scope.launch {
-                                    delay(100)
-                                    detailOpener.openCommunityDetail(community, instance)
-                                }
-                            },
-                            onOpenPost = { post, instance ->
-                                navigationCoordinator.closeSideMenu()
-                                scope.launch {
-                                    delay(100)
-                                    detailOpener.openPostDetail(post, instance)
-                                }
-                            },
-                            onOpenUser = { user, instance ->
-                                navigationCoordinator.closeSideMenu()
-                                scope.launch {
-                                    delay(100)
-                                    detailOpener.openUserDetail(user, instance)
-                                }
-                            },
-                            onOpenWeb = { url ->
-                                navigationCoordinator.closeSideMenu()
-                                scope.launch {
-                                    delay(100)
-                                    navigationCoordinator.pushScreen(WebViewScreen(url))
-                                }
+                                navigationCoordinator.pushScreen(
+                                    ZoomableImageScreen(
+                                        url = url,
+                                        source = uiState.community.readableHandle,
+                                    ),
+                                )
                             },
                         )
                     }

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -82,7 +82,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.uniqueIdentifier
 import com.livefast.eattrash.raccoonforlemmy.unit.explore.components.ExploreTopBar
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -356,17 +355,17 @@ class ExploreScreen(
                                                     )
 
                                                 ActionOnSwipe.DownVote ->
-                                                        SwipeAction(
-                                                            swipeContent = {
-                                                                Icon(
-                                                                    imageVector = Icons.Default.ArrowCircleDown,
-                                                                    contentDescription = null,
-                                                                    tint = Color.White,
-                                                                )
-                                                            },
-                                                            backgroundColor =
-                                                                downVoteColor
-                                                                    ?: defaultDownVoteColor,
+                                                    SwipeAction(
+                                                        swipeContent = {
+                                                            Icon(
+                                                                imageVector = Icons.Default.ArrowCircleDown,
+                                                                contentDescription = null,
+                                                                tint = Color.White,
+                                                            )
+                                                        },
+                                                        backgroundColor =
+                                                            downVoteColor
+                                                                ?: defaultDownVoteColor,
                                                         onTriggered = {
                                                             model.reduce(
                                                                 ExploreMviModel.Intent.DownVotePost(
@@ -455,14 +454,14 @@ class ExploreScreen(
                                                     )
                                                 },
                                                 onDoubleClick =
-                                                {
+                                                    {
                                                         model.reduce(
                                                             ExploreMviModel.Intent.UpVotePost(
-                                                                        id = result.model.id,
-                                                                        feedback = true,
-                                                                    ),
-                                                                )
-                                                }.takeIf { uiState.downVoteEnabled && uiState.isLogged && !isOnOtherInstance },
+                                                                id = result.model.id,
+                                                                feedback = true,
+                                                            ),
+                                                        )
+                                                    }.takeIf { uiState.downVoteEnabled && uiState.isLogged && !isOnOtherInstance },
                                                 onOpenCommunity = { community, instance ->
                                                     detailOpener.openCommunityDetail(
                                                         community = community,
@@ -512,20 +511,6 @@ class ExploreScreen(
                                                         ),
                                                     )
                                                 },
-                                                onOpenPost = { post, instance ->
-                                                    detailOpener.openPostDetail(
-                                                        post = post,
-                                                        otherInstance =
-                                                            instance.takeIf {
-                                                                it.isNotEmpty()
-                                                            } ?: otherInstanceName,
-                                                    )
-                                                },
-                                                onOpenWeb = { url ->
-                                                    navigationCoordinator.pushScreen(
-                                                        WebViewScreen(url),
-                                                    )
-                                                },
                                             )
                                         },
                                     )
@@ -563,15 +548,15 @@ class ExploreScreen(
                                                     )
 
                                                 ActionOnSwipe.DownVote ->
-                                                        SwipeAction(
-                                                            swipeContent = {
-                                                                Icon(
-                                                                    imageVector = Icons.Default.ArrowCircleDown,
-                                                                    contentDescription = null,
-                                                                    tint = Color.White,
-                                                                )
-                                                            },
-                                                            backgroundColor =
+                                                    SwipeAction(
+                                                        swipeContent = {
+                                                            Icon(
+                                                                imageVector = Icons.Default.ArrowCircleDown,
+                                                                contentDescription = null,
+                                                                tint = Color.White,
+                                                            )
+                                                        },
+                                                        backgroundColor =
                                                             downVoteColor
                                                                 ?: defaultDownVoteColor,
                                                         onTriggered = {
@@ -581,7 +566,7 @@ class ExploreScreen(
                                                                 ),
                                                             )
                                                         },
-                                                        ).takeIf { uiState.downVoteEnabled }
+                                                    ).takeIf { uiState.downVoteEnabled }
 
                                                 ActionOnSwipe.Reply ->
                                                     SwipeAction(
@@ -664,21 +649,21 @@ class ExploreScreen(
                                                     )
                                                 },
                                                 onDoubleClick =
-                                                {
-                                                            if (uiState.isLogged) {
-                                                                model.reduce(
-                                                                    ExploreMviModel.Intent.UpVoteComment(
-                                                                        id = result.model.id,
-                                                                        feedback = true,
-                                                                    ),
+                                                    {
+                                                        if (uiState.isLogged) {
+                                                            model.reduce(
+                                                                ExploreMviModel.Intent.UpVoteComment(
+                                                                    id = result.model.id,
+                                                                    feedback = true,
+                                                                ),
                                                             )
                                                         }
                                                     }.takeIf { uiState.doubleTapActionEnabled },
                                                 onUpVote =
-                                                {
-                                                            model.reduce(
-                                                                ExploreMviModel.Intent.UpVoteComment(
-                                                                    id = result.model.id,
+                                                    {
+                                                        model.reduce(
+                                                            ExploreMviModel.Intent.UpVoteComment(
+                                                                id = result.model.id,
                                                             ),
                                                         )
                                                     }.takeIf { uiState.isLogged },
@@ -714,22 +699,6 @@ class ExploreScreen(
                                                             instance.takeIf {
                                                                 it.isNotEmpty()
                                                             } ?: otherInstanceName,
-                                                    )
-                                                },
-                                                onOpenPost = { post, instance ->
-                                                    detailOpener.openPostDetail(
-                                                        post = post,
-                                                        otherInstance =
-                                                            instance.takeIf {
-                                                                it.isNotEmpty()
-                                                            } ?: otherInstanceName,
-                                                    )
-                                                },
-                                                onOpenWeb = { url ->
-                                                    navigationCoordinator.pushScreen(
-                                                        WebViewScreen(
-                                                            url,
-                                                        ),
                                                     )
                                                 },
                                             )

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -96,7 +96,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWit
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWithReasonScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -506,14 +505,6 @@ class FilteredContentsScreen(
                                         },
                                         onOpenCreator = { user, instance ->
                                             detailOpener.openUserDetail(user, instance)
-                                        },
-                                        onOpenPost = { p, instance ->
-                                            detailOpener.openPostDetail(p, instance)
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(
-                                                WebViewScreen(url),
-                                            )
                                         },
                                         onUpVote = {
                                             model.reduce(

--- a/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -30,15 +30,10 @@ import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.unit.licences.components.LicenceItem
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 
 class LicencesScreen : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -49,9 +44,7 @@ class LicencesScreen : Screen {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val settingsRepository = remember { getSettingsRepository() }
         val uriHandler = LocalUriHandler.current
-        val customTabsHelper = remember { getCustomTabsHelper() }
 
         Scaffold(
             modifier =
@@ -103,17 +96,7 @@ class LicencesScreen : Screen {
                                 .onClick(
                                     onClick = {
                                         if (item.url.isNotBlank()) {
-                                            navigationCoordinator.handleUrl(
-                                                url = item.url,
-                                                openingMode =
-                                                    settingsRepository.currentSettings.value.urlOpeningMode
-                                                        .toUrlOpeningMode(),
-                                                uriHandler = uriHandler,
-                                                customTabsHelper = customTabsHelper,
-                                                onOpenWeb = { url ->
-                                                    navigationCoordinator.pushScreen(WebViewScreen(url))
-                                                },
-                                            )
+                                            uriHandler.openUri(item.url)
                                         }
                                     },
                                 ),

--- a/unit/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/login/LoginBottomSheet.kt
+++ b/unit/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/login/LoginBottomSheet.kt
@@ -56,17 +56,12 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.autofill
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.safeImePadding
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toReadableMessage
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -84,8 +79,6 @@ class LoginBottomSheet : Screen {
         val genericError = LocalStrings.current.messageGenericError
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val uriHandler = LocalUriHandler.current
-        val customTabsHelper = remember { getCustomTabsHelper() }
-        val settingsRepository = remember { getSettingsRepository() }
         val instanceFocusRequester = remember { FocusRequester() }
         val usernameFocusRequester = remember { FocusRequester() }
         val passwordFocusRequester = remember { FocusRequester() }
@@ -135,17 +128,7 @@ class LoginBottomSheet : Screen {
                     actions = {
                         IconButton(
                             onClick = {
-                                navigationCoordinator.handleUrl(
-                                    url = HELP_URL,
-                                    openingMode =
-                                        settingsRepository.currentSettings.value.urlOpeningMode
-                                            .toUrlOpeningMode(),
-                                    uriHandler = uriHandler,
-                                    customTabsHelper = customTabsHelper,
-                                    onOpenWeb = { url ->
-                                        navigationCoordinator.pushScreen(WebViewScreen(url))
-                                    },
-                                )
+                                uriHandler.openUri(HELP_URL)
                             },
                         ) {
                             Icon(

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -90,7 +90,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWithReasonAction
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWithReasonScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -335,15 +334,15 @@ class MultiCommunityScreen(
                                         )
 
                                     ActionOnSwipe.DownVote ->
-                                            SwipeAction(
-                                                swipeContent = {
-                                                    Icon(
-                                                        imageVector = Icons.Default.ArrowCircleDown,
-                                                        contentDescription = null,
-                                                        tint = Color.White,
-                                                    )
-                                                },
-                                                backgroundColor = downVoteColor ?: defaultDownVoteColor,
+                                        SwipeAction(
+                                            swipeContent = {
+                                                Icon(
+                                                    imageVector = Icons.Default.ArrowCircleDown,
+                                                    contentDescription = null,
+                                                    tint = Color.White,
+                                                )
+                                            },
+                                            backgroundColor = downVoteColor ?: defaultDownVoteColor,
                                             onTriggered = {
                                                 model.reduce(
                                                     MultiCommunityMviModel.Intent.DownVotePost(
@@ -425,7 +424,7 @@ class MultiCommunityScreen(
                                         detailOpener.openPostDetail(post)
                                     },
                                     onDoubleClick =
-                                    {
+                                        {
                                             model.reduce(
                                                 MultiCommunityMviModel.Intent.UpVotePost(
                                                     id = post.id,
@@ -438,15 +437,6 @@ class MultiCommunityScreen(
                                     },
                                     onOpenCreator = { user, instance ->
                                         detailOpener.openUserDetail(user, instance)
-                                    },
-                                    onOpenPost = { post, instance ->
-                                        detailOpener.openPostDetail(
-                                            post = post,
-                                            otherInstance = instance,
-                                        )
-                                    },
-                                    onOpenWeb = { url ->
-                                        navigationCoordinator.pushScreen(WebViewScreen(url))
                                     },
                                     onUpVote = {
                                         model.reduce(

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -70,7 +70,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -321,14 +320,6 @@ object ProfileLoggedScreen : Tab {
                                     },
                                     onOpenCreator = { user, instance ->
                                         detailOpener.openUserDetail(user, instance)
-                                    },
-                                    onOpenPost = { p, instance ->
-                                        detailOpener.openPostDetail(p, instance)
-                                    },
-                                    onOpenWeb = { url ->
-                                        navigationCoordinator.pushScreen(
-                                            WebViewScreen(url),
-                                        )
                                     },
                                     onOpenImage = { url ->
                                         navigationCoordinator.pushScreen(

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -138,7 +138,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWit
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWithReasonScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -844,14 +843,6 @@ class PostDetailScreen(
                                         onOpenCreator = { user, instance ->
                                             detailOpener.openUserDetail(user, instance)
                                         },
-                                        onOpenPost = { p, instance ->
-                                            detailOpener.openPostDetail(p, instance)
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(
-                                                WebViewScreen(url),
-                                            )
-                                        },
                                         onUpVote = {
                                             if (uiState.isLogged && !isOnOtherInstance) {
                                                 model.reduce(
@@ -1207,14 +1198,6 @@ class PostDetailScreen(
                                                             detailOpener.openCommunityDetail(
                                                                 community,
                                                                 instance,
-                                                            )
-                                                        },
-                                                        onOpenPost = { p, instance ->
-                                                            detailOpener.openPostDetail(p, instance)
-                                                        },
-                                                        onOpenWeb = { url ->
-                                                            navigationCoordinator.pushScreen(
-                                                                WebViewScreen(url),
                                                             )
                                                         },
                                                         onImageClick = { url ->

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -101,7 +101,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.postlist.components.PostsTopBar
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
 import com.livefast.eattrash.raccoonforlemmy.unit.selectinstance.SelectInstanceBottomSheet
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -205,29 +204,29 @@ class PostListScreen : Screen {
                     onHamburgerTapped = {
                         scope.launch {
                             drawerCoordinator.toggleDrawer()
-                            }
-                        },
+                        }
+                    },
                     onSelectListingType = {
                         val sheet =
                             ListingTypeBottomSheet(
-                                    isLogged = uiState.isLogged,
-                                    screenKey = "postList",
-                                )
-                            navigationCoordinator.showBottomSheet(sheet)
-                        },
+                                isLogged = uiState.isLogged,
+                                screenKey = "postList",
+                            )
+                        navigationCoordinator.showBottomSheet(sheet)
+                    },
                     onSelectInstance =
-                    {
+                        {
                             navigationCoordinator.showBottomSheet(SelectInstanceBottomSheet())
-                    }.takeIf { uiState.isLogged },
+                        }.takeIf { uiState.isLogged },
                     onSelectSortType = {
                         val sheet =
                             SortBottomSheet(
                                 values = uiState.availableSortTypes.map { it.toInt() },
-                                    expandTop = true,
-                                    screenKey = "postList",
-                                )
-                            navigationCoordinator.showBottomSheet(sheet)
-                        },
+                                expandTop = true,
+                                screenKey = "postList",
+                            )
+                        navigationCoordinator.showBottomSheet(sheet)
+                    },
                 )
             },
             floatingActionButton = {
@@ -280,11 +279,11 @@ class PostListScreen : Screen {
                                             scope.launch {
                                                 runCatching {
                                                     lazyListState.scrollToItem(0)
-                                                        topAppBarState.heightOffset = 0f
-                                                        topAppBarState.contentOffset = 0f
-                                                    }
+                                                    topAppBarState.heightOffset = 0f
+                                                    topAppBarState.contentOffset = 0f
                                                 }
-                                            },
+                                            }
+                                        },
                                     )
                                 if (uiState.isLogged) {
                                     this +=
@@ -295,12 +294,12 @@ class PostListScreen : Screen {
                                                 model.reduce(PostListMviModel.Intent.ClearRead)
                                                 scope.launch {
                                                     runCatching {
-                                                            lazyListState.scrollToItem(0)
-                                                            topAppBarState.heightOffset = 0f
-                                                            topAppBarState.contentOffset = 0f
-                                                        }
+                                                        lazyListState.scrollToItem(0)
+                                                        topAppBarState.heightOffset = 0f
+                                                        topAppBarState.contentOffset = 0f
                                                     }
-                                                },
+                                                }
+                                            },
                                         )
 
                                     this +=
@@ -324,8 +323,8 @@ class PostListScreen : Screen {
                     rememberPullRefreshState(
                         refreshing = uiState.refreshing,
                         onRefresh = {
-                                model.reduce(PostListMviModel.Intent.Refresh())
-                            },
+                            model.reduce(PostListMviModel.Intent.Refresh())
+                        },
                     )
                 Box(
                     modifier =
@@ -399,8 +398,8 @@ class PostListScreen : Screen {
                                                         PostListMviModel.Intent.UpVotePost(
                                                             post.id,
                                                         ),
-                                                        )
-                                                    },
+                                                    )
+                                                },
                                             )
 
                                         ActionOnSwipe.DownVote ->
@@ -455,23 +454,23 @@ class PostListScreen : Screen {
                                                             post.id,
                                                         ),
                                                     )
-                                                    },
+                                                },
                                             )
 
                                         ActionOnSwipe.Edit ->
-                                                SwipeAction(
-                                                    swipeContent = {
-                                                        Icon(
-                                                            imageVector = Icons.Default.Edit,
-                                                            contentDescription = null,
-                                                            tint = Color.White,
-                                                        )
-                                                    },
-                                                    backgroundColor = MaterialTheme.colorScheme.tertiary,
-                                                    onTriggered = {
-                                                            detailOpener.openCreatePost(editedPost = post)
+                                            SwipeAction(
+                                                swipeContent = {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Edit,
+                                                        contentDescription = null,
+                                                        tint = Color.White,
+                                                    )
                                                 },
-                                                ).takeIf { canEdit }
+                                                backgroundColor = MaterialTheme.colorScheme.tertiary,
+                                                onTriggered = {
+                                                    detailOpener.openCreatePost(editedPost = post)
+                                                },
+                                            ).takeIf { canEdit }
 
                                         else -> null
                                     }
@@ -481,7 +480,7 @@ class PostListScreen : Screen {
                                 modifier = Modifier.fillMaxWidth(),
                                 enabled = uiState.swipeActionsEnabled,
                                 onGestureBegin = {
-                                        model.reduce(PostListMviModel.Intent.HapticIndication)
+                                    model.reduce(PostListMviModel.Intent.HapticIndication)
                                 },
                                 swipeToStartActions =
                                     uiState.actionsOnSwipeToStartPosts.toSwipeActions(
@@ -508,13 +507,13 @@ class PostListScreen : Screen {
                                         showUnreadComments = uiState.showUnreadComments,
                                         downVoteEnabled = uiState.downVoteEnabled,
                                         onClick = {
-                                                model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
+                                            model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
                                             model.reduce(PostListMviModel.Intent.WillOpenDetail)
                                             detailOpener.openPostDetail(post)
                                         },
                                         onDoubleClick =
-                                        {
-                                            model.reduce(
+                                            {
+                                                model.reduce(
                                                     PostListMviModel.Intent.UpVotePost(post.id),
                                                 )
                                             }.takeIf { uiState.doubleTapActionEnabled && uiState.isLogged },
@@ -525,57 +524,48 @@ class PostListScreen : Screen {
                                             )
                                         },
                                         onOpenCreator = { user, instance ->
-                                                detailOpener.openUserDetail(
+                                            detailOpener.openUserDetail(
                                                 user = user,
                                                 otherInstance = instance,
                                             )
                                         },
-                                        onOpenPost = { p, instance ->
-                                                detailOpener.openPostDetail(
-                                                post = p,
-                                                otherInstance = instance,
-                                            )
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
                                         onUpVote = {
-                                                if (uiState.isLogged) {
+                                            if (uiState.isLogged) {
                                                 model.reduce(
                                                     PostListMviModel.Intent.UpVotePost(post.id),
                                                 )
                                             }
                                         },
                                         onDownVote = {
-                                                if (uiState.isLogged) {
-                                                    model.reduce(
+                                            if (uiState.isLogged) {
+                                                model.reduce(
                                                     PostListMviModel.Intent.DownVotePost(
                                                         post.id,
                                                     ),
                                                 )
                                             }
-                                            },
+                                        },
                                         onSave = {
-                                                if (uiState.isLogged) {
-                                                    model.reduce(PostListMviModel.Intent.SavePost(post.id))
+                                            if (uiState.isLogged) {
+                                                model.reduce(PostListMviModel.Intent.SavePost(post.id))
                                             }
-                                            },
+                                        },
                                         onReply = {
-                                                if (uiState.isLogged) {
-                                                    model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
-                                                model.reduce(PostListMviModel.Intent.WillOpenDetail)
-                                                    detailOpener.openPostDetail(post)
-                                                }
-                                            },
-                                        onOpenImage = { url ->
+                                            if (uiState.isLogged) {
                                                 model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
+                                                model.reduce(PostListMviModel.Intent.WillOpenDetail)
+                                                detailOpener.openPostDetail(post)
+                                            }
+                                        },
+                                        onOpenImage = { url ->
+                                            model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
                                             navigationCoordinator.pushScreen(
                                                 ZoomableImageScreen(
-                                                        url = url,
+                                                    url = url,
                                                     source = post.community?.readableHandle.orEmpty(),
-                                                    ),
-                                                )
-                                            },
+                                                ),
+                                            )
+                                        },
                                         options =
                                             buildList {
                                                 this +=
@@ -631,8 +621,8 @@ class PostListScreen : Screen {
                                                 }
                                             },
                                         onOptionSelected = { optionId ->
-                                                when (optionId) {
-                                                    OptionId.Delete -> {
+                                            when (optionId) {
+                                                OptionId.Delete -> {
                                                     itemIdToDelete = post.id
                                                 }
 
@@ -640,91 +630,91 @@ class PostListScreen : Screen {
                                                     detailOpener.openCreatePost(editedPost = post)
                                                 }
 
-                                                    OptionId.Report -> {
-                                                        val screen =
-                                                            ModerateWithReasonScreen(
-                                                                actionId = ModerateWithReasonAction.ReportPost.toInt(),
-                                                                contentId = post.id,
-                                                            )
-                                                        navigationCoordinator.pushScreen(screen)
-                                                    }
-
-                                                    OptionId.CrossPost -> {
-                                                        detailOpener.openCreatePost(
-                                                            crossPost = post,
-                                                            forceCommunitySelection = true,
+                                                OptionId.Report -> {
+                                                    val screen =
+                                                        ModerateWithReasonScreen(
+                                                            actionId = ModerateWithReasonAction.ReportPost.toInt(),
+                                                            contentId = post.id,
                                                         )
-                                                    }
+                                                    navigationCoordinator.pushScreen(screen)
+                                                }
 
-                                                    OptionId.SeeRaw -> {
-                                                        rawContent = post
-                                                    }
+                                                OptionId.CrossPost -> {
+                                                    detailOpener.openCreatePost(
+                                                        crossPost = post,
+                                                        forceCommunitySelection = true,
+                                                    )
+                                                }
 
-                                                    OptionId.Hide ->
+                                                OptionId.SeeRaw -> {
+                                                    rawContent = post
+                                                }
+
+                                                OptionId.Hide ->
+                                                    model.reduce(
+                                                        PostListMviModel.Intent.Hide(post.id),
+                                                    )
+
+                                                OptionId.Share -> {
+                                                    val urls =
+                                                        listOfNotNull(
+                                                            post.originalUrl,
+                                                            "https://${uiState.instance}/post/${post.id}",
+                                                        ).distinct()
+                                                    if (urls.size == 1) {
                                                         model.reduce(
-                                                            PostListMviModel.Intent.Hide(post.id),
+                                                            PostListMviModel.Intent.Share(urls.first()),
                                                         )
-
-                                                    OptionId.Share -> {
-                                                        val urls =
-                                                            listOfNotNull(
-                                                                post.originalUrl,
-                                                                "https://${uiState.instance}/post/${post.id}",
-                                                            ).distinct()
-                                                        if (urls.size == 1) {
-                                                            model.reduce(
-                                                                PostListMviModel.Intent.Share(urls.first()),
-                                                            )
-                                                        } else {
-                                                            val screen = ShareBottomSheet(urls = urls)
-                                                            navigationCoordinator.showBottomSheet(screen)
-                                                        }
+                                                    } else {
+                                                        val screen = ShareBottomSheet(urls = urls)
+                                                        navigationCoordinator.showBottomSheet(screen)
                                                     }
+                                                }
 
-                                                    OptionId.Block -> {
+                                                OptionId.Block -> {
+                                                    val screen =
+                                                        BlockBottomSheet(
+                                                            userName =
+                                                                post.creator?.readableName(
+                                                                    uiState.preferNicknames,
+                                                                ),
+                                                            userId = post.creator?.id,
+                                                            communityName =
+                                                                post.community?.readableName(
+                                                                    uiState.preferNicknames,
+                                                                ),
+                                                            communityId = post.community?.id,
+                                                            instanceName = post.community?.host,
+                                                            instanceId = post.community?.instanceId,
+                                                            userInstanceName = post.creator?.host,
+                                                            userInstanceId = post.creator?.instanceId,
+                                                        )
+                                                    navigationCoordinator.showBottomSheet(screen)
+                                                }
+
+                                                OptionId.Copy -> {
+                                                    val texts =
+                                                        listOfNotNull(
+                                                            post.title.takeIf { it.isNotBlank() },
+                                                            post.text.takeIf { it.isNotBlank() },
+                                                        ).distinct()
+                                                    if (texts.size == 1) {
+                                                        model.reduce(
+                                                            PostListMviModel.Intent.Copy(texts.first()),
+                                                        )
+                                                    } else {
                                                         val screen =
-                                                            BlockBottomSheet(
-                                                                userName =
-                                                                    post.creator?.readableName(
-                                                                        uiState.preferNicknames,
-                                                                    ),
-                                                                userId = post.creator?.id,
-                                                                communityName =
-                                                                    post.community?.readableName(
-                                                                        uiState.preferNicknames,
-                                                                    ),
-                                                                communityId = post.community?.id,
-                                                                instanceName = post.community?.host,
-                                                                instanceId = post.community?.instanceId,
-                                                                userInstanceName = post.creator?.host,
-                                                                userInstanceId = post.creator?.instanceId,
+                                                            CopyPostBottomSheet(
+                                                                title = post.title,
+                                                                text = post.text,
                                                             )
                                                         navigationCoordinator.showBottomSheet(screen)
                                                     }
-
-                                                    OptionId.Copy -> {
-                                                        val texts =
-                                                            listOfNotNull(
-                                                                post.title.takeIf { it.isNotBlank() },
-                                                                post.text.takeIf { it.isNotBlank() },
-                                                            ).distinct()
-                                                        if (texts.size == 1) {
-                                                            model.reduce(
-                                                                PostListMviModel.Intent.Copy(texts.first()),
-                                                            )
-                                                        } else {
-                                                            val screen =
-                                                                CopyPostBottomSheet(
-                                                                    title = post.title,
-                                                                    text = post.text,
-                                                                )
-                                                            navigationCoordinator.showBottomSheet(screen)
-                                                        }
-                                                    }
-
-                                                    else -> Unit
                                                 }
-                                            },
+
+                                                else -> Unit
+                                            }
+                                        },
                                     )
                                 },
                             )
@@ -746,7 +736,7 @@ class PostListScreen : Screen {
                                     ) {
                                         Button(
                                             onClick = {
-                                                    model.reduce(PostListMviModel.Intent.LoadNextPage)
+                                                model.reduce(PostListMviModel.Intent.LoadNextPage)
                                             },
                                         ) {
                                             Text(
@@ -811,8 +801,8 @@ class PostListScreen : Screen {
                     Button(
                         modifier = Modifier.align(Alignment.CenterHorizontally),
                         onClick = {
-                                model.reduce(PostListMviModel.Intent.Refresh(hardReset = true))
-                            },
+                            model.reduce(PostListMviModel.Intent.Refresh(hardReset = true))
+                        },
                     ) {
                         Text(LocalStrings.current.buttonRetry)
                     }
@@ -833,8 +823,8 @@ class PostListScreen : Screen {
                         downVotes = content.downvotes,
                         isLogged = uiState.isLogged,
                         onDismiss = {
-                                rawContent = null
-                            },
+                            rawContent = null
+                        },
                         onQuote = { quotation ->
                             rawContent = null
                             if (quotation != null) {
@@ -845,10 +835,10 @@ class PostListScreen : Screen {
                                             append("> ")
                                             append(quotation)
                                             append("\n\n")
-                                            },
-                                    )
-                                }
-                            },
+                                        },
+                                )
+                            }
+                        },
                     )
                 }
             }

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/components/PostReportCard.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/components/PostReportCard.kt
@@ -5,29 +5,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.PostCardBody
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.PostCardImage
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.PostCardTitle
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.PostLinkBanner
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.handleUrl
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.getCustomTabsHelper
-import com.livefast.eattrash.raccoonforlemmy.core.utils.url.toUrlOpeningMode
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostReportModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.imageUrl
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 
 @Composable
 internal fun PostReportCard(
@@ -40,11 +31,7 @@ internal fun PostReportCard(
     options: List<Option> = emptyList(),
     onOptionSelected: ((OptionId) -> Unit)? = null,
 ) {
-    val navigationCoordinator = remember { getNavigationCoordinator() }
-    val detailOpener = remember { getDetailOpener() }
-    val settingsRepository = remember { getSettingsRepository() }
     val uriHandler = LocalUriHandler.current
-    val customTabsHelper = remember { getCustomTabsHelper() }
 
     InnerReportCard(
         modifier = modifier,
@@ -70,17 +57,6 @@ internal fun PostReportCard(
                             ),
                         text = title,
                         autoLoadImages = autoLoadImages,
-                        onOpenUser = { user, instance ->
-                            detailOpener.openUserDetail(user, instance)
-                        },
-                        onOpenPost = { post, instance ->
-                            detailOpener.openPostDetail(post, instance)
-                        },
-                        onOpenWeb = { url ->
-                            navigationCoordinator.pushScreen(
-                                WebViewScreen(url),
-                            )
-                        },
                     )
                 }
                 report.imageUrl.takeIf { it.isNotEmpty() }?.also { imageUrl ->
@@ -102,17 +78,6 @@ internal fun PostReportCard(
                             ),
                         text = text,
                         autoLoadImages = autoLoadImages,
-                        onOpenUser = { user, instance ->
-                            detailOpener.openUserDetail(user, instance)
-                        },
-                        onOpenPost = { post, instance ->
-                            detailOpener.openPostDetail(post, instance)
-                        },
-                        onOpenWeb = { url ->
-                            navigationCoordinator.pushScreen(
-                                WebViewScreen(url),
-                            )
-                        },
                     )
                 }
                 report.originalUrl?.also { url ->
@@ -120,14 +85,7 @@ internal fun PostReportCard(
                         modifier = Modifier.padding(top = Spacing.s, bottom = Spacing.xxs),
                         url = url,
                         onClick = {
-                            navigationCoordinator.handleUrl(
-                                url = url,
-                                openingMode =
-                                    settingsRepository.currentSettings.value.urlOpeningMode
-                                        .toUrlOpeningMode(),
-                                uriHandler = uriHandler,
-                                customTabsHelper = customTabsHelper,
-                            )
+                            uriHandler.openUri(url)
                         },
                     )
                 }

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -115,7 +115,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.ModerateWit
 import com.livefast.eattrash.raccoonforlemmy.unit.moderatewithreason.toInt
 import com.livefast.eattrash.raccoonforlemmy.unit.rawcontent.RawContentDialog
 import com.livefast.eattrash.raccoonforlemmy.unit.userinfo.UserInfoScreen
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -698,12 +697,6 @@ class UserDetailScreen(
                                                 otherInstance = instance,
                                             )
                                         },
-                                        onOpenPost = { p, instance ->
-                                            detailOpener.openPostDetail(p, instance)
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
-                                        },
                                         onReply =
                                             {
                                                 model.reduce(UserDetailMviModel.Intent.WillOpenDetail)
@@ -1025,15 +1018,6 @@ class UserDetailScreen(
                                                 user = user,
                                                 otherInstance = instance,
                                             )
-                                        },
-                                        onOpenPost = { post, instance ->
-                                            detailOpener.openPostDetail(
-                                                post = post,
-                                                otherInstance = instance,
-                                            )
-                                        },
-                                        onOpenWeb = { url ->
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
                                         },
                                         options =
                                             buildList {

--- a/unit/userinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
+++ b/unit/userinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
@@ -51,9 +51,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.utils.getPrettyNumber
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableName
 import com.livefast.eattrash.raccoonforlemmy.unit.userinfo.components.ModeratedCommunityCell
-import com.livefast.eattrash.raccoonforlemmy.unit.web.WebViewScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScreen
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.core.parameter.parametersOf
 
@@ -194,46 +192,13 @@ class UserInfoScreen(
                                     modifier = Modifier.fillMaxWidth(),
                                     text = biography,
                                     onOpenImage = { url ->
-                                        navigationCoordinator.closeSideMenu()
                                         scope.launch {
-                                            delay(100)
                                             navigationCoordinator.pushScreen(
                                                 ZoomableImageScreen(
                                                     url = url,
                                                     source = uiState.user.readableHandle,
                                                 ),
                                             )
-                                        }
-                                    },
-                                    onOpenCommunity = { community, instance ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            detailOpener.openCommunityDetail(
-                                                community,
-                                                instance,
-                                            )
-                                        }
-                                    },
-                                    onOpenPost = { post, instance ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            detailOpener.openPostDetail(post, instance)
-                                        }
-                                    },
-                                    onOpenUser = { user, instance ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            detailOpener.openUserDetail(user, instance)
-                                        }
-                                    },
-                                    onOpenWeb = { url ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            navigationCoordinator.pushScreen(WebViewScreen(url))
                                         }
                                     },
                                 )
@@ -292,11 +257,7 @@ class UserInfoScreen(
                                     autoLoadImages = uiState.autoLoadImages,
                                     community = community,
                                     onOpenCommunity = { _ ->
-                                        navigationCoordinator.closeSideMenu()
-                                        scope.launch {
-                                            delay(100)
-                                            detailOpener.openCommunityDetail(community)
-                                        }
+                                        detailOpener.openCommunityDetail(community)
                                     },
                                 )
                             }


### PR DESCRIPTION
This PR removes the `NavigationCoordinator#handlerUrl(String)` method and relies on composition locals to pass down the Composable hierarchy the custom logic to determine whether URLs can be opened as internal references to users/communities/posts (and if so, do it) or opened as web pages (internally, with custom tabs or in the external browser). 

This implies quite a lot of simplification since no callbacks have to be passed around and all the logic and settings lookup is centralized in a single place, moreover the binding can be changed with dependency injection so it's even more flexible than the previous approach which used an extension function (statically bound).