### PR TITLE
fix: pick image from gallery on Android < 11

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -78,5 +79,19 @@
                 <data android:mimeType="text/plain"/>
             </intent-filter>
         </activity-alias>
+
+        <!-- Trigger Google Play services to install the backported photo picker module. -->
+        <service
+                android:name="com.google.android.gms.metadata.ModuleDependencies"
+                android:enabled="false"
+                android:exported="false"
+                tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                    android:name="photopicker_activity:0:required"
+                    android:value="" />
+        </service>
     </application>
 </manifest>

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/gallery/GalleryHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/gallery/GalleryHelper.kt
@@ -86,7 +86,12 @@ class DefaultGalleryHelper(
                 }
             }
         SideEffect {
-            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            pickMedia.launch(
+                PickVisualMediaRequest
+                    .Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    .build(),
+            )
         }
     }
 }

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -505,13 +505,17 @@ class AccountSettingsScreen : Screen {
         if (openAvatarPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openAvatarPicker = false
-                model.reduce(AccountSettingsMviModel.Intent.AvatarSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(AccountSettingsMviModel.Intent.AvatarSelected(bytes))
+                }
             }
         }
         if (openBannerPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openBannerPicker = false
-                model.reduce(AccountSettingsMviModel.Intent.BannerSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(AccountSettingsMviModel.Intent.BannerSelected(bytes))
+                }
             }
         }
 

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -393,7 +393,9 @@ class InboxChatScreen(
             if (openImagePicker) {
                 galleryHelper.getImageFromGallery { bytes ->
                     openImagePicker = false
-                    model.reduce(InboxChatMviModel.Intent.ImageSelected(bytes))
+                    if (bytes.isNotEmpty()) {
+                        model.reduce(InboxChatMviModel.Intent.ImageSelected(bytes))
+                    }
                 }
             }
         }

--- a/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -466,7 +466,9 @@ class CreateCommentScreen(
             if (openImagePicker) {
                 galleryHelper.getImageFromGallery { bytes ->
                     openImagePicker = false
-                    model.reduce(CreateCommentMviModel.Intent.ImageSelected(bytes))
+                    if (bytes.isNotEmpty()) {
+                        model.reduce(CreateCommentMviModel.Intent.ImageSelected(bytes))
+                    }
                 }
             }
 

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -120,13 +120,17 @@ class CreatePostScreen(
         if (openImagePicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openImagePicker = false
-                model.reduce(CreatePostMviModel.Intent.ImageSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(CreatePostMviModel.Intent.ImageSelected(bytes))
+                }
             }
         }
         if (openImagePickerInBody) {
             galleryHelper.getImageFromGallery { bytes ->
                 openImagePickerInBody = false
-                model.reduce(CreatePostMviModel.Intent.InsertImageInBody(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(CreatePostMviModel.Intent.InsertImageInBody(bytes))
+                }
             }
         }
 

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -402,13 +402,17 @@ class EditCommunityScreen(
         if (openIconPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openIconPicker = false
-                model.reduce(EditCommunityMviModel.Intent.IconSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(EditCommunityMviModel.Intent.IconSelected(bytes))
+                }
             }
         }
         if (openBannerPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openBannerPicker = false
-                model.reduce(EditCommunityMviModel.Intent.BannerSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(EditCommunityMviModel.Intent.BannerSelected(bytes))
+                }
             }
         }
 


### PR DESCRIPTION
As stated [here](https://developer.android.com/training/data-storage/shared/photopicker#device-availability) the photo picker is not available on Android < 11 (API level 30) and this case, if not handled, leads the app to crash.

This PR introduces the fallback on the GMS backported version of the picker, moreover it adds a check to avoid processing empty byte arrays (e.g. when the user dismisses the picker bottom sheet).

The `PickVisualMediaRequest` is now created with its Builder instead of relying on the constructor, this is just a syntactic change with no impact on functionality or behaviour.