### PR TITLE
fix: remove persistable URI permission `FLAG_GRANT_READ_URI_PERMISSION`

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/gallery/GalleryHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/gallery/GalleryHelper.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforlemmy.core.utils.gallery
 
 import android.content.ContentValues
 import android.content.Context
-import android.content.Intent
 import android.os.Environment
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
@@ -68,11 +67,6 @@ class DefaultGalleryHelper(
         val pickMedia =
             rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
                 if (uri != null) {
-                    resolver.takePersistableUriPermission(
-                        uri,
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                    )
-
                     scope.launch(Dispatchers.IO) {
                         resolver.openInputStream(uri)?.use { stream ->
                             val bytes = stream.readBytes()


### PR DESCRIPTION
The flag `FLAG_GRANT_READ_URI_PERMISSION` is only needed when the access to the file needs to be preserved for a long time (across app restarts or when the app is sent to background) to perform long-running or periodic operations.

This is not the case with RFL, because the access to the file is only needed for uploading it to the server in a fire-and-forget way. The persistable permission request could cause crashes on some devices because manufacturer may impose a stricter limit to the amount of persistable permissions an app can be granted, and there is anyway a limit by Google to 512 (before 2020 it was 128).