### PR TITLE
fix: avoid dismissing bottom sheets on long press

### DIFF
--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomModalBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomModalBottomSheet.kt
@@ -88,13 +88,19 @@ fun CustomModalBottomSheet(
                                                     onSelected?.invoke(idx)
                                                 }
                                             },
-                                            onLongClick = {
-                                                sheetScope.launch {
-                                                    sheetState.hide()
-                                                }.invokeOnCompletion {
-                                                    onLongPress?.invoke(idx)
-                                                }
-                                            },
+                                            onLongClick =
+                                                if (onLongPress != null) {
+                                                    {
+                                                        sheetScope
+                                                            .launch {
+                                                                sheetState.hide()
+                                                            }.invokeOnCompletion {
+                                                                onLongPress(idx)
+                                                            }
+                                                    }
+                                                } else {
+                                                    null
+                                                },
                                         ).padding(
                                             horizontal = Spacing.m,
                                             vertical = Spacing.s,


### PR DESCRIPTION
Avoid dismissing bottom sheets on long press if there is no callback, because this would result in an incorrect state.