### PR TITLE
refactor: background notification checks

### DIFF
--- a/domain/inbox/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/inbox/notification/DefaultInboxNotificationChecker.kt
+++ b/domain/inbox/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/inbox/notification/DefaultInboxNotificationChecker.kt
@@ -3,11 +3,13 @@ package com.livefast.eattrash.raccoonforlemmy.domain.inbox.notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
-
-private const val TAG = "InboxNotificationCheck"
 
 class DefaultInboxNotificationChecker(
     private val context: Context,
@@ -23,13 +25,34 @@ class DefaultInboxNotificationChecker(
         WorkManager.getInstance(context).cancelAllWorkByTag(TAG)
 
         createNotificationChannel()
+
+        val constraints =
+            Constraints
+                .Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+        // check immediately with an expedited one-time request
+        OneTimeWorkRequestBuilder<CheckNotificationWorker>()
+            .addTag(TAG)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .setConstraints(constraints)
+            .build()
+            .also { req ->
+                WorkManager.getInstance(context).enqueue(req)
+            }
+
         PeriodicWorkRequestBuilder<CheckNotificationWorker>(
             repeatInterval = intervalMinutes,
             repeatIntervalTimeUnit = TimeUnit.MINUTES,
-        )
-            .addTag(TAG)
-            .build().apply {
-                WorkManager.getInstance(context).enqueue(this)
+        ).addTag(TAG)
+            .setConstraints(constraints)
+            .setInitialDelay(
+                5,
+                TimeUnit.MINUTES,
+            ).build()
+            .also { req ->
+                WorkManager.getInstance(context).enqueue(req)
             }
     }
 
@@ -51,5 +74,9 @@ class DefaultInboxNotificationChecker(
         val notificationManager: NotificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val TAG = "InboxNotificationChecker"
     }
 }


### PR DESCRIPTION
This modernizes the `CheckNotificationWorker` migrating it to be a `CoroutineWorker` (and thus avoiding having to deal with its internal scope). Moreover, the `CoroutineDispatcher` should NOT be passed as a constructor parameter because this prevents proper instantiation by the system factory.

Additionally, this PR changes `DefaultInboxNotificationChecker` to perform a one-shot execution at the beginning, scheduling repeated tasks at a later moment, to avoid an initial delay that the system may happen to insert.