### PR TITLE
refactor: unify localizables for notifications

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/DefaultL10nManager.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/DefaultL10nManager.kt
@@ -6,6 +6,8 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.Strings
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.localizableStrings
 
 internal class DefaultL10nManager : L10nManager {
+    override val currentValues: Strings get() = lyricist.strings
+
     override val lyricist: Lyricist<Strings> =
         Lyricist(
             defaultLanguageTag = Locales.EN,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/L10nManager.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/L10nManager.kt
@@ -4,6 +4,8 @@ import cafe.adriel.lyricist.Lyricist
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.Strings
 
 interface L10nManager {
+    val currentValues: Strings
+
     val lyricist: Lyricist<Strings>
 
     fun changeLanguage(lang: String)

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ArStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ArStrings.kt
@@ -444,4 +444,7 @@ internal val ArStrings =
         override val messageAuthIssueSegue1 = "تحديث القوة"
         override val messageAuthIssueSegue2 = "تسجيل الدخول مرة أخرى"
         override val messageAuthIssueSegue3 = "مسح بيانات التطبيق"
+        override val inboxNotificationTitle = "العناصر غير المقروءة"
+
+        override fun inboxNotificationContent(count: Int): String = " عنصر غير مقروء$count هناك "
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/BgStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/BgStrings.kt
@@ -454,4 +454,7 @@ internal val BgStrings =
         override val messageAuthIssueSegue3 = "изчистете данните на приложението"
         override val messageAuthIssueSegue1 = "принудително опресняване"
         override val messageAuthIssueSegue2 = "влезте отново"
+        override val inboxNotificationTitle = "Непрочетени елементи"
+
+        override fun inboxNotificationContent(count: Int): String = "Има $count непрочетени елемента"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/CsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/CsStrings.kt
@@ -451,4 +451,7 @@ internal val CsStrings =
         override val messageAuthIssueSegue3 = "vymazat data aplikace"
         override val messageAuthIssueSegue1 = "vynutit obnovení"
         override val messageAuthIssueSegue2 = "přihlaste se znovu"
+        override val inboxNotificationTitle = "Nepřečtené položky"
+
+        override fun inboxNotificationContent(count: Int): String = "Počet nepřečtených položek: $count"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DaStrings.kt
@@ -447,4 +447,7 @@ internal val DaStrings =
         override val messageAuthIssueSegue3 = "ryd applikationsdataene"
         override val messageAuthIssueSegue1 = "fremtvinge opdatering"
         override val messageAuthIssueSegue2 = "logge ind igen"
+        override val inboxNotificationTitle = "Ulæste elementer"
+
+        override fun inboxNotificationContent(count: Int): String = "Der er $count ulæste elementer"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DeStrings.kt
@@ -454,4 +454,7 @@ internal val DeStrings =
         override val messageAuthIssueSegue3 = "Löschen Sie die Anwendungsdaten"
         override val messageAuthIssueSegue1 = "Aktualisierung erzwingen"
         override val messageAuthIssueSegue2 = "nochmal anmelden"
+        override val inboxNotificationTitle = "Ungelesene Beiträge"
+
+        override fun inboxNotificationContent(count: Int): String = "Es gibt $count ungelesene Beiträge"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DefaultStrings.kt
@@ -439,4 +439,7 @@ internal open class DefaultStrings : Strings {
     override val settingsManageBanDomainPlaceholder = "Substring of URL to exclude"
     override val settingsManageBanStopWordPlaceholder = "Forbidden expression"
     override val settingsManageBanSectionStopWords = "Words"
+    override val inboxNotificationTitle = "Unread items"
+
+    override fun inboxNotificationContent(count: Int): String = "There are $count unread items"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ElStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ElStrings.kt
@@ -458,4 +458,7 @@ internal val ElStrings =
         override val messageAuthIssueSegue3 = "διαγράψτε τα δεδομένα της εφαρμογής"
         override val messageAuthIssueSegue1 = "δύναμη ανανέωσης"
         override val messageAuthIssueSegue2 = "συνδεθείτε ξανά"
+        override val inboxNotificationTitle = "Μη αναγνωσμένα στοιχεία"
+
+        override fun inboxNotificationContent(count: Int): String = "Υπάρχουν $count μη αναγνωσμένα στοιχεία"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EoStrings.kt
@@ -442,4 +442,7 @@ internal val EoStrings =
         override val settingsManageBanSectionDomains = "Domajnoj"
         override val settingsManageBanSectionStopWords = "Vortoj"
         override val settingsManageBanStopWordPlaceholder = "Malpermesita esprimo"
+        override val inboxNotificationTitle = "Nelegitaj eroj"
+
+        override fun inboxNotificationContent(count: Int): String = "Estas $count nelegitaj eroj"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EsStrings.kt
@@ -454,4 +454,7 @@ internal val EsStrings =
         override val settingsManageBanDomainPlaceholder = "Substring de una url a excluir"
         override val settingsManageBanSectionStopWords = "Palabras"
         override val settingsManageBanStopWordPlaceholder = "Expresión prohibida"
+        override val inboxNotificationTitle = "Elementos para leer"
+
+        override fun inboxNotificationContent(count: Int): String = "Hay $count elementos para leer"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/EtStrings.kt
@@ -449,4 +449,7 @@ internal val EtStrings =
         override val messageAuthIssueSegue3 = "tühjendage rakenduse andmed"
         override val messageAuthIssueSegue1 = "sundida värskendama"
         override val messageAuthIssueSegue2 = "logi uuesti sisse"
+        override val inboxNotificationTitle = "Lugemata üksused"
+
+        override fun inboxNotificationContent(count: Int): String = "Seal on $count lugemata üksust"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/FiStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/FiStrings.kt
@@ -446,4 +446,7 @@ internal val FiStrings =
         override val messageAuthIssueSegue1 = "pakottaa päivittämään"
         override val messageAuthIssueSegue2 = "Kirjaudu uudelleen"
         override val messageAuthIssueSegue3 = "tyhjennä sovellustiedot"
+        override val inboxNotificationTitle = "Lukemattomat kohteet"
+
+        override fun inboxNotificationContent(count: Int): String = "$count lukematonta kohdetta"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/FrStrings.kt
@@ -457,4 +457,7 @@ internal val FrStrings =
         override val settingsManageBanSectionStopWords = "Mots"
         override val settingsManageBanStopWordPlaceholder = "Expression interdite"
         override val settingsManageBanSectionDomains = "Domaines"
+        override val inboxNotificationTitle = "Éléments non lus"
+
+        override fun inboxNotificationContent(count: Int): String = "Il y a $count éléments non lus"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/GaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/GaStrings.kt
@@ -451,4 +451,7 @@ internal val GaStrings =
         override val settingsManageBanSectionDomains = "Fearainn"
         override val settingsManageBanSectionStopWords = "Focail"
         override val settingsManageBanStopWordPlaceholder = "Léiriú toirmiscthe"
+        override val inboxNotificationTitle = "Míreanna neamhléite"
+
+        override fun inboxNotificationContent(count: Int): String = "Tá $count mír neamhléite"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/HrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/HrStrings.kt
@@ -451,4 +451,7 @@ internal val HrStrings =
         override val messageAuthIssueSegue3 = "očistite podatke aplikacije"
         override val messageAuthIssueSegue1 = "prisilno osvježiti"
         override val messageAuthIssueSegue2 = "ponovno se prijavite"
+        override val inboxNotificationTitle = "Nepročitane stavke"
+
+        override fun inboxNotificationContent(count: Int): String = "Ima $count nepročitanih stavki"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/HuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/HuStrings.kt
@@ -455,4 +455,7 @@ internal val HuStrings =
         override val messageAuthIssueSegue3 = "törölje az alkalmazás adatait"
         override val messageAuthIssueSegue1 = "erőltesse a frissítést"
         override val messageAuthIssueSegue2 = "jelentkezz be újra"
+        override val inboxNotificationTitle = "Olvasatlan elemek"
+
+        override fun inboxNotificationContent(count: Int): String = "$count olvasatlan elem van"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -454,4 +454,7 @@ internal val ItStrings =
         override val settingsManageBanSectionDomains = "Domini"
         override val settingsManageBanSectionStopWords = "Parole"
         override val settingsManageBanStopWordPlaceholder = "Espressione vietata"
+        override val inboxNotificationTitle = "Elementi non letti"
+
+        override fun inboxNotificationContent(count: Int): String = "Ci sono $count elementi non letti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/LtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/LtStrings.kt
@@ -450,4 +450,7 @@ internal val LtStrings =
         override val messageAuthIssueSegue3 = "išvalyti programos duomenis"
         override val messageAuthIssueSegue1 = "priverstinai atnaujinti"
         override val messageAuthIssueSegue2 = "prisijunkite dar kartą"
+        override val inboxNotificationTitle = "Neskaityti elementai"
+
+        override fun inboxNotificationContent(count: Int): String = "Yra $count neskaitytų elementų"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/LvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/LvStrings.kt
@@ -449,4 +449,7 @@ internal val LvStrings =
         override val messageAuthIssueSegue3 = "notīriet lietojumprogrammas datus"
         override val messageAuthIssueSegue1 = "piespiest atsvaidzināt"
         override val messageAuthIssueSegue2 = "piesakieties vēlreiz"
+        override val inboxNotificationTitle = "Nelasīti vienumi"
+
+        override fun inboxNotificationContent(count: Int): String = "Ir $count nelasīti vienumi"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/MtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/MtStrings.kt
@@ -451,4 +451,7 @@ internal val MtStrings =
         override val messageAuthIssueSegue3 = "ċara d-dejta tal-applikazzjoni"
         override val messageAuthIssueSegue1 = "iġiegħel l-aġġornament"
         override val messageAuthIssueSegue2 = "erġa\' illoggja"
+        override val inboxNotificationTitle = "Oġġetti mhux moqrija"
+
+        override fun inboxNotificationContent(count: Int): String = "Hemm $count oġġetti mhux moqrija"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/NlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/NlStrings.kt
@@ -451,4 +451,7 @@ internal val NlStrings =
         override val messageAuthIssueSegue1 = "geforceerd vernieuwen"
         override val messageAuthIssueSegue2 = "Log opnieuw in"
         override val messageAuthIssueSegue3 = "Wis de toepassingsgegevens"
+        override val inboxNotificationTitle = "Ongelezen items"
+
+        override fun inboxNotificationContent(count: Int): String = "Er zijn $count ongelezen items"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/NnStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/NnStrings.kt
@@ -447,4 +447,7 @@ internal val NnStrings =
         override val messageAuthIssueSegue0 = "Du kan prøve en av følgende handlinger:"
         override val messageAuthIssueSegue2 = "logge på igjen"
         override val messageAuthIssueSegue3 = "slett applikasjonsdataene"
+        override val inboxNotificationTitle = "Uleste elementer"
+
+        override fun inboxNotificationContent(count: Int): String = "Det er $count uleste elementer"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PlStrings.kt
@@ -453,4 +453,7 @@ internal val PlStrings =
         override val messageAuthIssueSegue3 = "wyczyść dane aplikacji"
         override val messageAuthIssueSegue1 = "wymuś odświeżenie"
         override val messageAuthIssueSegue2 = "Zaloguj się jeszcze raz"
+        override val inboxNotificationTitle = "Nieprzeczytane elementy"
+
+        override fun inboxNotificationContent(count: Int): String = "Istnieje $count nieprzeczytanych elementów"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PtBrStrings.kt
@@ -447,4 +447,7 @@ internal val PtBrStrings =
         override val settingsManageBanSectionDomains = "Domínios"
         override val settingsManageBanSectionStopWords = "Palavras"
         override val settingsManageBanStopWordPlaceholder = "Frases proibidas"
+        override val inboxNotificationTitle = "Itens não lidos"
+
+        override fun inboxNotificationContent(count: Int): String = "Você tem $count itens não lidos"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/PtStrings.kt
@@ -451,4 +451,7 @@ internal val PtStrings =
         override val selectTabNavigationTitle = "Selecione uma seção"
         override val messageAuthIssueSegue0 = "Você pode tentar uma das seguintes ações:"
         override val messageAuthIssueSegue2 = "fazer login novamente"
+        override val inboxNotificationTitle = "Itens não lidos"
+
+        override fun inboxNotificationContent(count: Int): String = "Existem $count itens não lidos"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/RoStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/RoStrings.kt
@@ -450,4 +450,7 @@ internal val RoStrings =
         override val settingsManageBanSectionDomains = "Domenii"
         override val settingsManageBanSectionStopWords = "Cuvinte"
         override val settingsManageBanStopWordPlaceholder = "Expresie interzisă"
+        override val inboxNotificationTitle = "Elemente necitite"
+
+        override fun inboxNotificationContent(count: Int): String = "Există $count elemente necitite"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/RuStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/RuStrings.kt
@@ -452,4 +452,7 @@ internal val RuStrings =
         override val selectTabNavigationTitle = "Выберите раздел"
         override val messageAuthIssueSegue0 = "Вы можете попробовать одно из следующих действий:"
         override val messageAuthIssueSegue2 = "войдите снова"
+        override val inboxNotificationTitle = "Непрочитанные элементы"
+
+        override fun inboxNotificationContent(count: Int): String = "Непрочитанных элементов: $count"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SkStrings.kt
@@ -454,4 +454,7 @@ internal val SkStrings =
         override val messageAuthIssueSegue1 = "vynútiť obnovenie"
         override val messageAuthIssueSegue2 = "prihláste sa znova"
         override val messageAuthIssueSegue3 = "vymazať údaje aplikácie"
+        override val inboxNotificationTitle = "Neprečítané položky"
+
+        override fun inboxNotificationContent(count: Int): String = "Počet neprečítaných položiek: $count"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SlStrings.kt
@@ -451,4 +451,7 @@ internal val SlStrings =
         override val messageAuthIssueSegue1 = "prisilno osveži"
         override val messageAuthIssueSegue2 = "znova se prijavite"
         override val messageAuthIssueSegue3 = "počistite podatke aplikacije"
+        override val inboxNotificationTitle = "Neprebrani predmeti"
+
+        override fun inboxNotificationContent(count: Int): String = "$count neprebranih elementov"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SqStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SqStrings.kt
@@ -453,4 +453,7 @@ internal val SqStrings =
         override val messageAuthIssueSegue1 = "forco refresh"
         override val messageAuthIssueSegue2 = "hyni përsëri"
         override val messageAuthIssueSegue3 = "pastroni të dhënat e aplikacionit"
+        override val inboxNotificationTitle = "Artikuj të palexuar"
+
+        override fun inboxNotificationContent(count: Int): String = "Ka $count artikuj të palexuar"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SrStrings.kt
@@ -453,4 +453,7 @@ internal val SrStrings =
         override val messageAuthIssueSegue1 = "принудно освежавање"
         override val messageAuthIssueSegue2 = "пријавите се поново"
         override val messageAuthIssueSegue3 = "обришите податке апликације"
+        override val inboxNotificationTitle = "Непрочитане ставке"
+
+        override fun inboxNotificationContent(count: Int): String = "Постоји $count непрочитаних ставки"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -437,6 +437,9 @@ interface Strings {
     val settingsManageBanDomainPlaceholder: String
     val settingsManageBanSectionStopWords: String
     val settingsManageBanStopWordPlaceholder: String
+    val inboxNotificationTitle: String
+
+    fun inboxNotificationContent(count: Int): String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SvStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/SvStrings.kt
@@ -448,4 +448,7 @@ internal val SvStrings =
         override val messageAuthIssueSegue1 = "tvinga fram uppdatering"
         override val messageAuthIssueSegue2 = "logga in igen"
         override val messageAuthIssueSegue3 = "rensa applikationsdata"
+        override val inboxNotificationTitle = "Olästa objekt"
+
+        override fun inboxNotificationContent(count: Int): String = "Det finns $count olästa objekt"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/TokStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/TokStrings.kt
@@ -443,4 +443,7 @@ internal val TokStrings =
         override val settingsManageBanDomainPlaceholder = "o weka e sitelen pi nimi linluwi"
         override val settingsManageBanSectionStopWords = "nimi"
         override val settingsManageBanStopWordPlaceholder = "o weka e sitelen"
+        override val inboxNotificationTitle = "ijo pi wile lukin"
+
+        override fun inboxNotificationContent(count: Int): String = "ijo $count pi wile lukin li lon"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/TrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/TrStrings.kt
@@ -449,4 +449,7 @@ internal val TrStrings =
         override val messageAuthIssueSegue3 = "uygulama verilerini temizle"
         override val messageAuthIssueSegue1 = "yenilemeye zorla"
         override val messageAuthIssueSegue2 = "Tekrar giriş yap"
+        override val inboxNotificationTitle = "Okunmamış öğeler"
+
+        override fun inboxNotificationContent(count: Int): String = "$count okunmamış öğe var"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/UkStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/UkStrings.kt
@@ -452,4 +452,7 @@ internal val UkStrings =
         override val messageAuthIssueSegue3 = "очистити дані програми"
         override val messageAuthIssueSegue1 = "примусово оновити"
         override val messageAuthIssueSegue2 = "увійдіть знову"
+        override val inboxNotificationTitle = "Непрочитані елементи"
+
+        override fun inboxNotificationContent(count: Int): String = "Непрочитаних елементів:$count"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ZhTwStrings.kt
@@ -414,4 +414,7 @@ internal val ZhTwStrings =
         override val settingsEnableToggleFavoriteInNavDrawer = "加入/移除導航抽屜中的收藏"
         override val messageContentDeleted = "您已刪除此內容"
         override val actionRestore = "恢復"
+        override val inboxNotificationTitle = "未讀項目"
+
+        override fun inboxNotificationContent(count: Int): String = "有${count}未讀項目"
     }

--- a/domain/inbox/build.gradle.kts
+++ b/domain/inbox/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
 
                 implementation(libs.koin.core)
 
+                implementation(projects.core.l10n)
                 implementation(projects.core.resources)
 
                 implementation(projects.domain.identity)
@@ -64,9 +65,15 @@ kotlin {
 
 android {
     namespace = "com.livefast.eattrash.raccoonforlemmy.domain.inbox"
-    compileSdk = libs.versions.android.targetSdk.get().toInt()
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
     defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
     }
 }
 

--- a/domain/inbox/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/inbox/notification/CheckNotificationWorker.kt
+++ b/domain/inbox/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/inbox/notification/CheckNotificationWorker.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import android.content.Intent
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.livefast.eattrash.raccoonforlemmy.core.l10n.L10nManager
 import com.livefast.eattrash.raccoonforlemmy.domain.inbox.InboxCoordinator
-import com.livefast.eattrash.raccoonforlemmy.domain.inbox.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent.inject
@@ -21,6 +21,7 @@ internal class CheckNotificationWorker(
     parameters: WorkerParameters,
 ) : CoroutineWorker(context, parameters) {
     private val inboxCoordinator by inject<InboxCoordinator>(InboxCoordinator::class.java)
+    private val l10nManager by inject<L10nManager>(L10nManager::class.java)
 
     override suspend fun doWork() =
         withContext(Dispatchers.IO) {
@@ -34,8 +35,8 @@ internal class CheckNotificationWorker(
 
     @SuppressLint("StringFormatInvalid")
     private fun sendNotification(count: Int) {
-        val title = context.getString(R.string.inbox_notification_title)
-        val content = context.getString(R.string.inbox_notification_content, count)
+        val title = l10nManager.currentValues.inboxNotificationTitle
+        val content = l10nManager.currentValues.inboxNotificationContent(count)
         val notification =
             Notification
                 .Builder(context, NotificationConstants.CHANNEL_ID)

--- a/domain/inbox/src/androidMain/res/values-ar/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-ar/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">العناصر غير المقروءة</string>
-    <string name="inbox_notification_content">هناك %1$d عنصر غير مقروء</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-bg/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-bg/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Непрочетени елементи</string>
-    <string name="inbox_notification_content">Има %1$d непрочетени елемента</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-cs/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-cs/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Nepřečtené položky</string>
-    <string name="inbox_notification_content">Počet nepřečtených položek: %1$d</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-da/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-da/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Ulæste elementer</string>
-    <string name="inbox_notification_content">Der er %1$d ulæste elementer</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-de/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-de/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Ungelesene Beiträge</string>
-    <string name="inbox_notification_content">Es gibt %1$d ungelesene Beiträge</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-el/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-el/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Μη αναγνωσμένα στοιχεία</string>
-    <string name="inbox_notification_content">Υπάρχουν %1$d μη αναγνωσμένα στοιχεία</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-eo/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-eo/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Nelegitaj eroj</string>
-    <string name="inbox_notification_content">Estas %1$d nelegitaj eroj</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-es/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-es/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Elementos para leer</string>
-    <string name="inbox_notification_content">Hay %1$d elementos para leer</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-et/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-et/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Lugemata üksused</string>
-    <string name="inbox_notification_content">Seal on %1$d lugemata üksust</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-fi/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-fi/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Lukemattomat kohteet</string>
-    <string name="inbox_notification_content">%1$d lukematonta kohdetta</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-fr/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-fr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Éléments non lus</string>
-    <string name="inbox_notification_content">Il y a %1$d éléments non lus</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-ga/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-ga/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Míreanna neamhléite</string>
-    <string name="inbox_notification_content">Tá %1$d mír neamhléite</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-hr/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-hr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Nepročitane stavke</string>
-    <string name="inbox_notification_content">Ima %1$d nepročitanih stavki</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-hu/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-hu/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Olvasatlan elemek</string>
-    <string name="inbox_notification_content">%1$d olvasatlan elem van</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-it/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-it/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Elementi non letti</string>
-    <string name="inbox_notification_content">Ci sono %1$d elementi non letti</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-lt/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-lt/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Neskaityti elementai</string>
-    <string name="inbox_notification_content">Yra %1$d neskaitytų elementų</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-lv/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-lv/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Nelasīti vienumi</string>
-    <string name="inbox_notification_content">Ir %1$d nelasīti vienumi</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-mt/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-mt/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Oġġetti mhux moqrija</string>
-    <string name="inbox_notification_content">Hemm %1$d oġġetti mhux moqrija</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-nb/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-nb/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Uleste elementer</string>
-    <string name="inbox_notification_content">Det er %1$d uleste elementer</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-nl/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-nl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Ongelezen items</string>
-    <string name="inbox_notification_content">Er zijn %1$d ongelezen items</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-nn/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-nn/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Uleste elementer</string>
-    <string name="inbox_notification_content">Det er %1$d uleste elementer</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-pl/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-pl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Nieprzeczytane elementy</string>
-    <string name="inbox_notification_content">Istnieje %1$d nieprzeczytanych elementów</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-pt-rBR/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-pt-rBR/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Itens não lidos</string>
-    <string name="inbox_notification_content">Você tem %1$d itens não lidos</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-pt/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-pt/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Itens não lidos</string>
-    <string name="inbox_notification_content">Existem %1$d itens não lidos</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-ro/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-ro/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Elemente necitite</string>
-    <string name="inbox_notification_content">Există %1$d elemente necitite</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-ru/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-ru/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Непрочитанные элементы</string>
-    <string name="inbox_notification_content">Непрочитанных элементов: %1$d</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-sk/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-sk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Neprečítané položky</string>
-    <string name="inbox_notification_content">Počet neprečítaných položiek: %1$d</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-sl/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-sl/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Neprebrani predmeti</string>
-    <string name="inbox_notification_content">%1$d neprebranih elementov</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-sq/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-sq/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Artikuj të palexuar</string>
-    <string name="inbox_notification_content">Ka %1$d artikuj të palexuar</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-sr/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-sr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Непрочитане ставке</string>
-    <string name="inbox_notification_content">Постоји %1$d непрочитаних ставки</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-sv/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-sv/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Olästa objekt</string>
-    <string name="inbox_notification_content">Det finns %1$d olästa objekt</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-tok/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-tok/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">ijo pi wile lukin</string>
-    <string name="inbox_notification_content">ijo %1$d pi wile lukin li lon</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-tr/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-tr/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Okunmamış öğeler</string>
-    <string name="inbox_notification_content">%1$d okunmamış öğe var</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-uk/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-uk/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Непрочитані елементи</string>
-    <string name="inbox_notification_content">Непрочитаних елементів: %1$d</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/domain/inbox/src/androidMain/res/values-zh-rTW/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">未讀項目</string>
-    <string name="inbox_notification_content">有%1$d未讀項目</string>
-</resources>

--- a/domain/inbox/src/androidMain/res/values/strings.xml
+++ b/domain/inbox/src/androidMain/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="inbox_notification_title">Unread items</string>
-    <string name="inbox_notification_content">There are %1$d unread items</string>
-</resources>


### PR DESCRIPTION
This PR unifies all the localizable resources in Lyricist files, removing module-specific and platform-specific resources used just for notifications.