### PR TITLE
fix: make sure text after an empty quote is rendered

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
@@ -72,10 +72,16 @@ private fun String.spoilerFixUp(): String =
 private fun String.quoteFixUp(): String =
     run {
         val finalLines = mutableListOf<String>()
+        val quoteAndList = Regex("^>-")
+        val quoteEmpty = Regex("^>\\s*$")
         lines().forEach { line ->
-            // removes list inside quotes
-            val quoteAndList = Regex("^>-")
-            val cleanLine = line.replace(quoteAndList, "-")
+
+            val cleanLine =
+                line
+                    // removes list inside quotes
+                    .replace(quoteAndList, "-")
+                    // replace empty quotes
+                    .replace(quoteEmpty, " \n")
             val isLastEmpty = finalLines.isNotEmpty() && finalLines.last().isEmpty()
             if (!isLastEmpty || cleanLine.isNotEmpty()) {
                 finalLines += cleanLine


### PR DESCRIPTION
There was an issue with markdown due to which, if inside a quote there was an empty line, all the text coming afterwards was not rendered, e.g.:
```
> some random quote
> 
> this is not rendered
```

Original report [on Lemmy](https://lemmy.world/post/21437975).

This PR add as sanitization workaround to avoid that issue. I am more and more disappointed with the Markdown rendering library, and I really wished something else existed for Compose Multiplatform.