### PR TITLE
fix: restore user manual URL

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ email: livefast.eattrash.raccoon@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Raccoon for Lemmy 🦝 documentation
 baseurl: "/RaccoonForLemmy" # the subpath of your site, e.g. /blog
-url: "https://example.com" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://livefasteattrashraccoon.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 theme: minima

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsConstants.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsConstants.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforlemmy.feature.settings.main
+
+internal object SettingsConstants {
+    const val USER_MANUAL_URL = "https://livefasteattrashraccoon.github.io/RaccoonForLemmy/user_manual/main"
+}

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -376,7 +376,7 @@ class SettingsScreen : Screen {
                         value = "",
                         disclosureIndicator = true,
                         onTap = {
-                            uriHandler.openUri("https://example.com")
+                            uriHandler.openUri(SettingsConstants.USER_MANUAL_URL)
                         },
                     )
 


### PR DESCRIPTION
This PR restores the in-app link to user manual.