### PR TITLE
fix: reset UI state when block option selected

### DIFF
--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -1638,7 +1638,7 @@ class CommunityDetailScreen(
                 }
             }
             CustomModalBottomSheet(
-                title = LocalStrings.current.communityDetailBlock,
+                title = LocalStrings.current.actionCopyClipboard,
                 items = values,
                 onSelected = { index ->
                     copyPostBottomSheet = null

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -2040,7 +2040,7 @@ class PostDetailScreen(
                 }
             }
             CustomModalBottomSheet(
-                title = LocalStrings.current.communityDetailBlock,
+                title = LocalStrings.current.actionCopyClipboard,
                 items = values,
                 onSelected = { index ->
                     copyPostBottomSheet = null

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -1030,7 +1030,7 @@ class PostListScreen : Screen {
                 }
             }
             CustomModalBottomSheet(
-                title = LocalStrings.current.communityDetailBlock,
+                title = LocalStrings.current.actionCopyClipboard,
                 items = values,
                 onSelected = { index ->
                     copyPostBottomSheet = null

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -963,7 +963,7 @@ class PostListScreen : Screen {
                         )
                     },
                 onSelected = { index ->
-                    shareBottomSheetUrls = null
+                    blockBottomSheetItems = null
                     if (index != null) {
                         val value = values[index]
                         val event =

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -1249,7 +1249,7 @@ class UserDetailScreen(
                 }
             }
             CustomModalBottomSheet(
-                title = LocalStrings.current.communityDetailBlock,
+                title = LocalStrings.current.actionCopyClipboard,
                 items = values,
                 onSelected = { index ->
                     copyPostBottomSheet = null


### PR DESCRIPTION
This PR fixes a bug due to which the UI was unresponsive after dismissing the block bottom sheet in the home screen. Double checked that that bottom sheet is used just there.