### PR TITLE
refactor: migrate SelectNumberBottomSheet to M3 modal bottom sheet

### DIFF
--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SelectNumberBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SelectNumberBottomSheet.kt
@@ -1,36 +1,37 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.modals
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import cafe.adriel.voyager.core.screen.Screen
+import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.BottomSheetHeader
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 sealed interface SelectNumberBottomSheetType {
     data object PostBodyMaxLines : SelectNumberBottomSheetType
@@ -45,7 +46,7 @@ private fun SelectNumberBottomSheetType.toReadableTitle() =
         SelectNumberBottomSheetType.PostBodyMaxLines -> LocalStrings.current.settingsPostBodyMaxLines
     }
 
-private fun SelectNumberBottomSheetType.toInt() =
+fun SelectNumberBottomSheetType.toInt() =
     when (this) {
         SelectNumberBottomSheetType.InboxPreviewMaxLines -> 1
         SelectNumberBottomSheetType.PostBodyMaxLines -> 0
@@ -57,101 +58,97 @@ fun Int.toSelectNumberBottomSheetType(): SelectNumberBottomSheetType =
         else -> SelectNumberBottomSheetType.PostBodyMaxLines
     }
 
-class SelectNumberBottomSheet(
-    private val values: List<Int?> =
-        listOf(
-            10,
-            30,
-            50,
-            -1, // custom number
-            null, // unlimited
-        ),
-    private val initialValue: Int?,
-    private val type: SelectNumberBottomSheetType,
-) : Screen {
-    @Composable
-    override fun Content() {
-        val navigationCoordinator = remember { getNavigationCoordinator() }
-        val notificationCenter = remember { getNotificationCenter() }
-        var customDialogOpened by remember { mutableStateOf(false) }
+private const val CUSTOM = -1
+private const val UNLIMITED = -2
 
-        Surface {
-            Column(
-                modifier =
-                    Modifier
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .padding(
-                            top = Spacing.s,
-                            start = Spacing.s,
-                            end = Spacing.s,
-                            bottom = Spacing.m,
-                        ),
-                verticalArrangement = Arrangement.spacedBy(Spacing.s),
-            ) {
-                BottomSheetHeader(title = type.toReadableTitle())
-                Column(
-                    modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
-                ) {
-                    for (value in values) {
-                        Row(
-                            modifier =
-                                Modifier
-                                    .clip(RoundedCornerShape(CornerSize.xxl))
-                                    .onClick(
-                                        onClick = {
-                                            if (value != null && value < 0) {
-                                                customDialogOpened = true
-                                            } else {
-                                                notificationCenter.send(
-                                                    NotificationCenterEvent.SelectNumberBottomSheetClosed(
-                                                        value = value,
-                                                        type = type.toInt(),
-                                                    ),
-                                                )
-                                                navigationCoordinator.hideBottomSheet()
-                                            }
-                                        },
-                                    ).padding(
-                                        horizontal = Spacing.s,
-                                        vertical = Spacing.s,
-                                    ).fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            val text =
-                                when {
-                                    value == null -> LocalStrings.current.settingsPostBodyMaxLinesUnlimited
-                                    value < 0 -> LocalStrings.current.settingsColorCustom
-                                    else -> value.toString()
-                                }
-                            Text(
-                                text = text,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = MaterialTheme.colorScheme.onBackground,
-                            )
-                        }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectNumberBottomSheet(
+    sheetScope: CoroutineScope = rememberCoroutineScope(),
+    state: SheetState = rememberModalBottomSheetState(),
+    values: List<Int?> =
+        listOf(
+            1,
+            10,
+            50,
+            CUSTOM,
+            UNLIMITED,
+        ),
+    initialValue: Int?,
+    type: SelectNumberBottomSheetType,
+    onSelected: ((Int?) -> Unit)? = null,
+) {
+    var customDialogOpened by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        sheetState = state,
+        onDismissRequest = {
+            onSelected?.invoke(null)
+        },
+    ) {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xl),
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = type.toReadableTitle(),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(Spacing.xs))
+            LazyColumn {
+                items(values) { value ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(CornerSize.xl))
+                                .clickable {
+                                    if (value == CUSTOM) {
+                                        customDialogOpened = true
+                                    } else {
+                                        onSelected?.invoke(value)
+                                    }
+                                }.padding(
+                                    horizontal = Spacing.m,
+                                    vertical = Spacing.s,
+                                ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                    ) {
+                        val text =
+                            when (value) {
+                                UNLIMITED -> LocalStrings.current.settingsPostBodyMaxLinesUnlimited
+                                CUSTOM -> LocalStrings.current.settingsColorCustom
+                                else -> value.toString()
+                            }
+                        Text(
+                            text = text,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
                     }
                 }
             }
+        }
 
-            if (customDialogOpened) {
-                NumberPickerDialog(
-                    title = LocalStrings.current.settingsColorCustom,
-                    initialValue = initialValue ?: 0,
-                    onClose = {
-                        customDialogOpened = false
-                    },
-                    onSubmit = { value ->
-                        notificationCenter.send(
-                            NotificationCenterEvent.SelectNumberBottomSheetClosed(
-                                value = value,
-                                type = type.toInt(),
-                            ),
-                        )
-                        navigationCoordinator.hideBottomSheet()
-                    },
-                )
-            }
+        if (customDialogOpened) {
+            NumberPickerDialog(
+                title = LocalStrings.current.settingsColorCustom,
+                initialValue = initialValue ?: 0,
+                onClose = {
+                    customDialogOpened = false
+                },
+                onSubmit = { value ->
+                    sheetScope
+                        .launch {
+                            state.hide()
+                        }.invokeOnCompletion {
+                            onSelected?.invoke(value)
+                        }
+                },
+            )
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -58,6 +58,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectLanguage
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SliderBottomSheet
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
@@ -113,6 +114,7 @@ class AdvancedSettingsScreen : Screen {
         var inboxTypeBottomSheetOpened by remember { mutableStateOf(false) }
         var exploreListingTypeBottomSheetOpened by remember { mutableStateOf(false) }
         var exploreResultTypeBottomSheetOpened by remember { mutableStateOf(false) }
+        var selectNumberBottomSheetOpened by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects
@@ -306,20 +308,7 @@ class AdvancedSettingsScreen : Screen {
                                     uiState.inboxPreviewMaxLines.toString()
                                 },
                             onTap = {
-                                val screen =
-                                    SelectNumberBottomSheet(
-                                        values =
-                                            listOf(
-                                                1,
-                                                10,
-                                                50,
-                                                -1, // custom number
-                                                null, // unlimited
-                                            ),
-                                        type = SelectNumberBottomSheetType.InboxPreviewMaxLines,
-                                        initialValue = uiState.inboxPreviewMaxLines,
-                                    )
-                                navigationCoordinator.showBottomSheet(screen)
+                                selectNumberBottomSheetOpened = true
                             },
                         )
                     }
@@ -882,6 +871,24 @@ class AdvancedSettingsScreen : Screen {
                 }
                 settingsContent = null
             }
+        }
+
+        if (selectNumberBottomSheetOpened) {
+            SelectNumberBottomSheet(
+                type = SelectNumberBottomSheetType.InboxPreviewMaxLines,
+                initialValue = uiState.inboxPreviewMaxLines,
+                onSelected = { value ->
+                    selectNumberBottomSheetOpened = false
+                    if (value != null) {
+                        notificationCenter.send(
+                            NotificationCenterEvent.SelectNumberBottomSheetClosed(
+                                value = value.takeIf { it > 0 },
+                                type = SelectNumberBottomSheetType.InboxPreviewMaxLines.toInt(),
+                            ),
+                        )
+                    }
+                },
+            )
         }
     }
 }

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -54,6 +54,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBot
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
@@ -74,6 +75,7 @@ class ConfigureContentViewScreen : Screen {
         var postLayoutBottomSheetOpened by remember { mutableStateOf(false) }
         var fontFamilyBottomSheetOpened by remember { mutableStateOf(false) }
         var fontScaleClassBottomSheet by remember { mutableStateOf<ContentFontClass?>(null) }
+        var selectNumberBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
             modifier =
@@ -199,12 +201,7 @@ class ConfigureContentViewScreen : Screen {
                                     uiState.postBodyMaxLines.toString()
                                 },
                             onTap = {
-                                val screen =
-                                    SelectNumberBottomSheet(
-                                        type = SelectNumberBottomSheetType.PostBodyMaxLines,
-                                        initialValue = uiState.postBodyMaxLines,
-                                    )
-                                navigationCoordinator.showBottomSheet(screen)
+                                selectNumberBottomSheetOpened = true
                             },
                         )
                     }
@@ -409,6 +406,24 @@ class ConfigureContentViewScreen : Screen {
                             NotificationCenterEvent.ChangeContentFontSize(
                                 value = items[index],
                                 contentClass = contentClass,
+                            ),
+                        )
+                    }
+                },
+            )
+        }
+
+        if (selectNumberBottomSheetOpened) {
+            SelectNumberBottomSheet(
+                type = SelectNumberBottomSheetType.PostBodyMaxLines,
+                initialValue = uiState.postBodyMaxLines,
+                onSelected = { value ->
+                    selectNumberBottomSheetOpened = false
+                    if (value != null) {
+                        notificationCenter.send(
+                            NotificationCenterEvent.SelectNumberBottomSheetClosed(
+                                value = value.takeIf { it > 0 },
+                                type = SelectNumberBottomSheetType.PostBodyMaxLines.toInt(),
                             ),
                         )
                     }


### PR DESCRIPTION
Continue bottom sheet overhaul rewriting `SelectNumberBottomSheet` using Material3's `ModalBottomSheet`.