### PR TITLE
refactor: migrate SliderBottomSheet to M3

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -114,7 +114,8 @@ class AdvancedSettingsScreen : Screen {
         var inboxTypeBottomSheetOpened by remember { mutableStateOf(false) }
         var exploreListingTypeBottomSheetOpened by remember { mutableStateOf(false) }
         var exploreResultTypeBottomSheetOpened by remember { mutableStateOf(false) }
-        var selectNumberBottomSheetOpened by remember { mutableStateOf(false) }
+        var selectInboxPreviewMaxLinesBottomSheetOpened by remember { mutableStateOf(false) }
+        var selectZombieModeAmount by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects
@@ -308,7 +309,7 @@ class AdvancedSettingsScreen : Screen {
                                     uiState.inboxPreviewMaxLines.toString()
                                 },
                             onTap = {
-                                selectNumberBottomSheetOpened = true
+                                selectInboxPreviewMaxLinesBottomSheetOpened = true
                             },
                         )
                     }
@@ -408,13 +409,7 @@ class AdvancedSettingsScreen : Screen {
                                 append(LocalStrings.current.settingsPointsShort)
                             },
                         onTap = {
-                            val sheet =
-                                SliderBottomSheet(
-                                    min = 0f,
-                                    max = screenWidth,
-                                    initial = uiState.zombieModeScrollAmount,
-                                )
-                            navigationCoordinator.showBottomSheet(sheet)
+                            selectZombieModeAmount = true
                         },
                     )
 
@@ -873,18 +868,35 @@ class AdvancedSettingsScreen : Screen {
             }
         }
 
-        if (selectNumberBottomSheetOpened) {
+        if (selectInboxPreviewMaxLinesBottomSheetOpened) {
             SelectNumberBottomSheet(
                 type = SelectNumberBottomSheetType.InboxPreviewMaxLines,
                 initialValue = uiState.inboxPreviewMaxLines,
                 onSelected = { value ->
-                    selectNumberBottomSheetOpened = false
+                    selectInboxPreviewMaxLinesBottomSheetOpened = false
                     if (value != null) {
                         notificationCenter.send(
                             NotificationCenterEvent.SelectNumberBottomSheetClosed(
                                 value = value.takeIf { it > 0 },
                                 type = SelectNumberBottomSheetType.InboxPreviewMaxLines.toInt(),
                             ),
+                        )
+                    }
+                },
+            )
+        }
+
+        if (selectZombieModeAmount) {
+            SliderBottomSheet(
+                title = LocalStrings.current.settingsZombieModeScrollAmount,
+                min = 0f,
+                max = screenWidth,
+                initial = uiState.zombieModeScrollAmount,
+                onSelected = { value ->
+                    selectZombieModeAmount = false
+                    if (value != null) {
+                        notificationCenter.send(
+                            NotificationCenterEvent.ChangeZombieScrollAmount(value),
                         )
                     }
                 },

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -75,7 +75,7 @@ class ConfigureContentViewScreen : Screen {
         var postLayoutBottomSheetOpened by remember { mutableStateOf(false) }
         var fontFamilyBottomSheetOpened by remember { mutableStateOf(false) }
         var fontScaleClassBottomSheet by remember { mutableStateOf<ContentFontClass?>(null) }
-        var selectNumberBottomSheetOpened by remember { mutableStateOf(false) }
+        var selectPostBodyMaxLinesBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
             modifier =
@@ -201,7 +201,7 @@ class ConfigureContentViewScreen : Screen {
                                     uiState.postBodyMaxLines.toString()
                                 },
                             onTap = {
-                                selectNumberBottomSheetOpened = true
+                                selectPostBodyMaxLinesBottomSheetOpened = true
                             },
                         )
                     }
@@ -413,12 +413,12 @@ class ConfigureContentViewScreen : Screen {
             )
         }
 
-        if (selectNumberBottomSheetOpened) {
+        if (selectPostBodyMaxLinesBottomSheetOpened) {
             SelectNumberBottomSheet(
                 type = SelectNumberBottomSheetType.PostBodyMaxLines,
                 initialValue = uiState.postBodyMaxLines,
                 onSelected = { value ->
-                    selectNumberBottomSheetOpened = false
+                    selectPostBodyMaxLinesBottomSheetOpened = false
                     if (value != null) {
                         notificationCenter.send(
                             NotificationCenterEvent.SelectNumberBottomSheetClosed(


### PR DESCRIPTION
This PR migrated `SliderBottomSheet` to Material3's `ModalBottomSheet`.