### PR TITLE
refactor: migrate SelectInstanceBottomSheet to M3

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -297,6 +297,7 @@ internal object ProfileMainScreen : Tab {
                     Button(
                         onClick = {
                             logoutConfirmDialogOpened = false
+                            navigationCoordinator.closeSideMenu()
                             model.reduce(ProfileMainMviModel.Intent.Logout)
                         },
                     ) {

--- a/unit/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
+++ b/unit/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drawer/ModalDrawerContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -86,6 +87,7 @@ object ModalDrawerContent : Tab {
                     }
                 }
             }
+        var selectInstanceBottomSheetOpened by remember { mutableStateOf(false) }
 
         var uiFontSizeWorkaround by remember { mutableStateOf(true) }
         LaunchedEffect(themeRepository) {
@@ -100,6 +102,7 @@ object ModalDrawerContent : Tab {
         if (!uiFontSizeWorkaround) {
             return
         }
+
         LaunchedEffect(notificationCenter) {
             notificationCenter
                 .subscribe(NotificationCenterEvent.InstanceSelected::class)
@@ -115,7 +118,7 @@ object ModalDrawerContent : Tab {
                 instance = uiState.instance,
                 autoLoadImages = uiState.autoLoadImages,
                 onOpenChangeInstance = {
-                    navigationCoordinator.showBottomSheet(SelectInstanceBottomSheet())
+                    selectInstanceBottomSheetOpened = true
                 },
                 onOpenSwitchAccount = {
                     navigationCoordinator.showBottomSheet(ManageAccountsScreen())
@@ -347,6 +350,19 @@ object ModalDrawerContent : Tab {
                     }
                 }
             }
+        }
+
+        if (selectInstanceBottomSheetOpened) {
+            SelectInstanceBottomSheet(
+                parent = this,
+                state = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                onSelected = { instance ->
+                    selectInstanceBottomSheetOpened = false
+                    if (instance != null) {
+                        notificationCenter.send(NotificationCenterEvent.InstanceSelected(instance))
+                    }
+                },
+            )
         }
     }
 }

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -151,6 +152,7 @@ class PostListScreen : Screen {
         }
         var sortBottomSheetOpened by remember { mutableStateOf(false) }
         var copyPostBottomSheet by remember { mutableStateOf<PostModel?>(null) }
+        var selectInstanceBottomSheetOpened by remember { mutableStateOf(false) }
 
         LaunchedEffect(navigationCoordinator) {
             navigationCoordinator.onDoubleTabSelection
@@ -217,7 +219,7 @@ class PostListScreen : Screen {
                     },
                     onSelectInstance =
                         {
-                            navigationCoordinator.showBottomSheet(SelectInstanceBottomSheet())
+                            selectInstanceBottomSheetOpened = true
                         }.takeIf { !uiState.isLogged },
                     onSelectSortType = {
                         sortBottomSheetOpened = true
@@ -1037,6 +1039,19 @@ class PostListScreen : Screen {
                     if (index != null) {
                         val text = texts[index]
                         clipboardManager.setText(AnnotatedString(text))
+                    }
+                },
+            )
+        }
+
+        if (selectInstanceBottomSheetOpened) {
+            SelectInstanceBottomSheet(
+                parent = this,
+                state = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                onSelected = { instance ->
+                    selectInstanceBottomSheetOpened = false
+                    if (instance != null) {
+                        notificationCenter.send(NotificationCenterEvent.InstanceSelected(instance))
                     }
                 },
             )

--- a/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/SelectInstanceBottomSheet.kt
+++ b/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/SelectInstanceBottomSheet.kt
@@ -1,11 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.selectinstance
 
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,94 +14,110 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.BottomSheetHeader
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.getScreenModel
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.unit.selectinstance.components.SelectInstanceItem
 import com.livefast.eattrash.raccoonforlemmy.unit.selectinstance.dialog.ChangeInstanceDialog
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
-class SelectInstanceBottomSheet : Screen {
-    @OptIn(ExperimentalFoundationApi::class)
-    @Composable
-    override fun Content() {
-        val model = getScreenModel<SelectInstanceMviModel>(key)
-        val uiState by model.uiState.collectAsState()
-        var changeInstanceDialogOpen by remember {
-            mutableStateOf(false)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectInstanceBottomSheet(
+    sheetScope: CoroutineScope = rememberCoroutineScope(),
+    state: SheetState = rememberModalBottomSheetState(),
+    parent: Screen,
+    onSelected: ((String?) -> Unit)? = null,
+) {
+    val model = parent.getScreenModel<SelectInstanceMviModel>(parent.key)
+    val uiState by model.uiState.collectAsState()
+    var changeInstanceDialogOpen by remember {
+        mutableStateOf(false)
+    }
+
+    val lazyListState = rememberLazyListState()
+    val reorderableLazyColumnState =
+        rememberReorderableLazyListState(lazyListState) { from, to ->
+            model.reduce(
+                SelectInstanceMviModel.Intent.SwapIntances(
+                    from = from.index - 1,
+                    to = to.index - 1,
+                ),
+            )
         }
-        val notificationCenter = remember { getNotificationCenter() }
-        val navigationCoordinator = remember { getNavigationCoordinator() }
-        val lazyListState = rememberLazyListState()
-        val reorderableLazyColumnState =
-            rememberReorderableLazyListState(lazyListState) { from, to ->
-                model.reduce(
-                    SelectInstanceMviModel.Intent.SwapIntances(
-                        from = from.index - 1,
-                        to = to.index - 1,
-                    ),
-                )
-            }
-        var instanceToDelete by remember { mutableStateOf<String?>(null) }
+    var instanceToDelete by remember { mutableStateOf<String?>(null) }
 
-        LaunchedEffect(model) {
-            model.effects
-                .onEach { evt ->
-                    when (evt) {
-                        SelectInstanceMviModel.Effect.CloseDialog -> {
-                            changeInstanceDialogOpen = false
-                        }
-
-                        is SelectInstanceMviModel.Effect.Confirm -> {
-                            notificationCenter.send(NotificationCenterEvent.InstanceSelected(evt.instance))
-                            navigationCoordinator.hideBottomSheet()
-                        }
+    LaunchedEffect(model) {
+        model.effects
+            .onEach { evt ->
+                when (evt) {
+                    SelectInstanceMviModel.Effect.CloseDialog -> {
+                        changeInstanceDialogOpen = false
                     }
-                }.launchIn(this)
-        }
 
+                    is SelectInstanceMviModel.Effect.Confirm -> {
+                        sheetScope
+                            .launch {
+                                state.hide()
+                            }.invokeOnCompletion {
+                                onSelected?.invoke(evt.instance)
+                            }
+                    }
+                }
+            }.launchIn(this)
+    }
+
+    ModalBottomSheet(
+        sheetState = state,
+        onDismissRequest = {
+            onSelected?.invoke(null)
+        },
+    ) {
         Column(
-            modifier =
-                Modifier
-                    .padding(
-                        top = Spacing.s,
-                        start = Spacing.s,
-                        end = Spacing.s,
-                        bottom = Spacing.m,
-                    ).fillMaxHeight(0.6f),
-            verticalArrangement = Arrangement.spacedBy(Spacing.s),
+            modifier = Modifier.padding(bottom = Spacing.xl),
         ) {
             Box(
                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.s),
             ) {
-                BottomSheetHeader(LocalStrings.current.dialogTitleChangeInstance)
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                    text = LocalStrings.current.dialogTitleChangeInstance,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+
                 IconButton(
                     modifier = Modifier.align(Alignment.TopEnd),
                     onClick = {
@@ -118,7 +132,7 @@ class SelectInstanceBottomSheet : Screen {
             }
             LazyColumn(
                 state = lazyListState,
-                modifier = Modifier.fillMaxWidth().weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
             ) {
                 if (uiState.instances.isEmpty()) {
@@ -153,6 +167,8 @@ class SelectInstanceBottomSheet : Screen {
                         val isActive = instance == uiState.currentInstance
                         val elevation by animateDpAsState(if (isDragging) 4.dp else 0.dp)
                         Surface(
+                            color = Color.Transparent,
+                            tonalElevation = 1.5.dp,
                             shadowElevation = elevation,
                         ) {
                             SelectInstanceItem(

--- a/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/components/SelectInstanceItem.kt
+++ b/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/components/SelectInstanceItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
@@ -60,8 +61,9 @@ internal fun SelectInstanceItem(
                         onClick?.invoke()
                     },
                 ).padding(
-                    horizontal = Spacing.m,
-                    vertical = Spacing.s,
+                    top = Spacing.s,
+                    bottom = Spacing.s,
+                    start = Spacing.m,
                 ),
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
         verticalAlignment = Alignment.CenterVertically,
@@ -75,6 +77,12 @@ internal fun SelectInstanceItem(
 
         if (isActive) {
             RadioButton(
+                modifier =
+                    Modifier.padding(
+                        top = Spacing.s,
+                        bottom = Spacing.s,
+                        end = Spacing.s,
+                    ),
                 selected = true,
                 onClick = null,
             )
@@ -82,11 +90,9 @@ internal fun SelectInstanceItem(
 
         if (options.isNotEmpty()) {
             Box {
-                Icon(
+                IconButton(
                     modifier =
                         Modifier
-                            .size(IconSize.m)
-                            .padding(Spacing.xs)
                             .then(
                                 with(reorderableScope) {
                                     Modifier.draggableHandle(
@@ -97,15 +103,21 @@ internal fun SelectInstanceItem(
                                 },
                             ).onGloballyPositioned {
                                 optionsOffset = it.positionInParent()
-                            }.onClick(
-                                onClick = {
-                                    optionsMenuOpen = true
-                                },
-                            ),
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = null,
-                    tint = ancillaryColor,
-                )
+                            },
+                    onClick = {
+                        optionsMenuOpen = true
+                    },
+                ) {
+                    Icon(
+                        modifier =
+                            Modifier
+                                .size(IconSize.m)
+                                .padding(Spacing.xs),
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = null,
+                        tint = ancillaryColor,
+                    )
+                }
 
                 CustomDropDown(
                     expanded = optionsMenuOpen,


### PR DESCRIPTION
We're finally getting there! `SelectInstanceBottomSheet` is the second-to-last bottom sheet still using Voyager's `BottomSheetNavigator`.

This migration was a little more complex because the bottom sheet had an associated view model, so it need to get tied to the lifecycle of the container screen.