### PR TITLE
fix: restore UI state after closing default sort bottom sheet in community detail

### DIFF
--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -1601,12 +1601,14 @@ class CommunityDetailScreen(
                 values = uiState.availableSortTypes,
                 expandTop = true,
                 onSelected = { value ->
+                    val wasDefaultSortBottomSheetOpened = defaultSortBottomSheetOpened
                     sortBottomSheetOpened = false
+                    defaultSortBottomSheetOpened = false
                     if (value != null) {
                         notificationCenter.send(
                             NotificationCenterEvent.ChangeSortType(
                                 value = value,
-                                defaultForCommunity = defaultSortBottomSheetOpened,
+                                defaultForCommunity = wasDefaultSortBottomSheetOpened,
                                 screenKey = uiState.community.readableHandle,
                             ),
                         )


### PR DESCRIPTION
As per title, this fixes a bug due to which after changing the default sort type for a community the UI became unresponsive.