### PR TITLE
enhancement: add new instances to default list

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultInstanceSelectionRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultInstanceSelectionRepository.kt
@@ -8,19 +8,22 @@ import kotlinx.coroutines.withContext
 private const val CUSTOM_INSTANCES_KEY = "customInstances"
 private val DEFAULT_INSTANCES =
     listOf(
-        "lemmy.world",
-        "lemmy.ml",
-        "lemmy.dbzer0.com",
-        "sh.itjust.works",
-        "lemm.ee",
-        "feddit.de",
-        "programming.dev",
         "discuss.tchncs.de",
-        "sopuli.xyz",
+        "feddit.it",
+        "infosec.pub",
+        "lemm.ee",
         "lemmy.blahaj.zone",
-        "lemmy.zip",
-        "reddthat.com",
         "lemmy.cafe",
+        "lemmy.dbzer0.com",
+        "lemmy.ml",
+        "lemmy.sdf.org",
+        "lemmy.world",
+        "lemmy.zip",
+        "mander.xyz",
+        "programming.dev",
+        "reddthat.com",
+        "sh.itjust.works",
+        "sopuli.xyz",
     )
 
 internal class DefaultInstanceSelectionRepository(
@@ -28,7 +31,8 @@ internal class DefaultInstanceSelectionRepository(
 ) : InstanceSelectionRepository {
     override suspend fun getAll(): List<String> =
         withContext(Dispatchers.IO) {
-            if (!keyStore.containsKey(CUSTOM_INSTANCES_KEY)) {
+            val isVersion1 = keyStore.get(CUSTOM_INSTANCES_KEY, listOf()).contains("feddit.de")
+            if (!keyStore.containsKey(CUSTOM_INSTANCES_KEY) || isVersion1) {
                 keyStore.save(key = CUSTOM_INSTANCES_KEY, value = DEFAULT_INSTANCES)
             }
             keyStore.get(key = CUSTOM_INSTANCES_KEY, default = DEFAULT_INSTANCES)

--- a/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/components/SelectInstanceItem.kt
+++ b/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/components/SelectInstanceItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ancillaryTextAlpha
@@ -81,7 +82,7 @@ internal fun SelectInstanceItem(
                     Modifier.padding(
                         top = Spacing.s,
                         bottom = Spacing.s,
-                        end = Spacing.s,
+                        end = 10.dp,
                     ),
                 selected = true,
                 onClick = null,


### PR DESCRIPTION
This PR updates the default instance list in the "Select instance" bottom sheet:
- remove feddit.de ⚰️ ;
- add feddit.it, infosec.pub, lemmy.sdf.org, mander.xyz;
- sort items alphabetically;
- reset list if contains legacy values.