### PR TITLE
chore(deps): update compose multiplatform from 1.7.0 to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="badge for Kotlin" src="https://img.shields.io/badge/Kotlin-2.0.21-7F52FF?logo=kotlin" />
   <img alt="badge for Gradle" src="https://img.shields.io/badge/Gradle-8.8-02303A?logo=gradle" />
   <img alt="badge for Android" src="https://img.shields.io/badge/Android-26+-34A853?logo=android" />
-  <img alt="badge for Compose Multiplatform" src="https://img.shields.io/badge/Compose-1.7.0-4285F4?logo=jetpackcompose" />
+  <img alt="badge for Compose Multiplatform" src="https://img.shields.io/badge/Compose-1.7.1-4285F4?logo=jetpackcompose" />
   <img alt="badge for project license" src="https://img.shields.io/github/license/LiveFastEatTrashRaccoon/RaccoonForLemmy" />
   <img alt="badge for build status" src="https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/actions/workflows/build.yml/badge.svg" />
   <img alt="badge for unit test status" src="https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/actions/workflows/unit_tests.yml/badge.svg" />

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
@@ -1,10 +1,12 @@
 package com.livefast.eattrash.raccoonforlemmy.feature.inbox.main
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Menu
@@ -25,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.CurrentScreen
@@ -32,6 +35,7 @@ import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheet
@@ -42,7 +46,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoo
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.unit.mentions.InboxMentionsScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.messages.InboxMessagesScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.replies.InboxRepliesScreen
@@ -112,12 +115,10 @@ object InboxScreen : Tab {
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .padding(horizontal = Spacing.s)
-                                    .onClick(
-                                        onClick = {
-                                            inboxTypeBottomSheetOpened = true
-                                        },
-                                    ),
+                                    .clip(RoundedCornerShape(CornerSize.xl))
+                                    .clickable {
+                                        inboxTypeBottomSheetOpened = true
+                                    }.padding(horizontal = Spacing.s),
                         ) {
                             Text(
                                 text = LocalStrings.current.navigationInbox,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ android-gradle = "8.5.2"
 calf = "0.6.1"
 coil = "3.0.2"
 colorpicker = "1.1.2"
-compose = "1.7.0"
+compose = "1.7.1"
 compose-multiplatform-media-player = "1.0.26"
 detekt = "1.23.7"
 koin = "4.0.0"
@@ -67,7 +67,6 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
-koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
@@ -1,11 +1,13 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.explore.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
@@ -26,10 +28,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SearchResultType
@@ -120,14 +123,16 @@ internal fun ExploreTopBar(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = Spacing.s)
-                        .onClick(
-                            onClick = {
-                                if (otherInstance.isEmpty()) {
+                        .clip(RoundedCornerShape(CornerSize.xl))
+                        .then(
+                            if (otherInstance.isEmpty()) {
+                                Modifier.clickable {
                                     onSelectListingType?.invoke()
                                 }
+                            } else {
+                                Modifier
                             },
-                        ),
+                        ).padding(horizontal = Spacing.s),
             ) {
                 Text(
                     text =

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/components/PostsTopBar.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/components/PostsTopBar.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.postlist.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -27,11 +29,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
@@ -106,36 +109,31 @@ internal fun PostsTopBar(
             }
         },
         title = {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = Spacing.s),
-            ) {
+            Column {
                 Text(
                     modifier =
-                        Modifier.fillMaxWidth().onClick(
-                            onClick = {
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(CornerSize.xl))
+                            .clickable {
                                 onSelectListingType?.invoke()
-                            },
-                        ),
+                            }.padding(horizontal = Spacing.s),
                     text = listingType?.toReadableName().orEmpty(),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
                 Text(
                     modifier =
-                        Modifier.fillMaxWidth().then(
-                                Modifier.onClick(
-                                    onClick = {
-                                    if (onSelectInstance != null) {
-                                        onSelectInstance.invoke()
-                                    } else {
-                                        onSelectListingType?.invoke()
-                                    }
-                                },
-                            ),
-                        ),
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(CornerSize.xl))
+                            .clickable {
+                                if (onSelectInstance != null) {
+                                    onSelectInstance.invoke()
+                                } else {
+                                    onSelectListingType?.invoke()
+                                }
+                            }.padding(horizontal = Spacing.s),
                     text =
                         buildString {
                             append(LocalStrings.current.homeInstanceVia)

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.reportlist
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Report
@@ -39,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
@@ -46,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.SectionSelector
@@ -61,7 +65,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoo
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentReportModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostReportModel
@@ -128,8 +131,9 @@ class ReportListScreen(
                         }
                     },
                     title = {
-                        Column(modifier = Modifier.padding(horizontal = Spacing.s)) {
+                        Column(modifier = Modifier) {
                             Text(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
                                 text = LocalStrings.current.reportListTitle,
                                 style = MaterialTheme.typography.titleMedium,
                             )
@@ -140,11 +144,12 @@ class ReportListScreen(
                                 }
                             Text(
                                 modifier =
-                                    Modifier.onClick(
-                                        onClick = {
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(CornerSize.xl))
+                                        .clickable {
                                             reportTypeBottomSheetOpened = true
-                                        },
-                                    ),
+                                        }.padding(horizontal = Spacing.s),
                                 text = text,
                                 style = MaterialTheme.typography.titleSmall,
                             )


### PR DESCRIPTION
This PR updates Compose Multiplatform to 1.7.1 and fixes the ripple effects in some application top bars.