### PR TITLE
fix: video rendering timeline and attachment detail

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Technical details
-<!-- Describe the motivation and scope of your changes…  -->
+<!-- Describe the motivation and scope of your changes  -->
+This PR …
 
 ## Additional notes
 <!-- Anything to declare for code review? -->

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -58,4 +58,4 @@ practices, please contact us at livefast.eattrash.raccoon@gmail.com.
 
 --- 
 
-Last updated: 2024-10-16
+Last updated: 2024-11-16

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
@@ -3,6 +3,8 @@ package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -19,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.text.style.TextOverflow
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.VideoPlayer
@@ -38,8 +41,11 @@ fun PostCardVideo(
     }
 
     Box(
-        modifier = modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .aspectRatio(16 / 9f).clipToBounds(),
+            contentAlignment = Alignment.Center,
     ) {
         if (blurred) {
             Column(
@@ -67,7 +73,7 @@ fun PostCardVideo(
             var shouldBeRendered by remember(autoLoadImages) { mutableStateOf(autoLoadImages) }
             if (shouldBeRendered) {
                 VideoPlayer(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxSize(),
                     url = url,
                 )
 

--- a/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
@@ -234,6 +234,7 @@ class ZoomableImageScreen(
                             VideoPlayer(
                                 url = url,
                                 muted = false,
+                                contentScale = ContentScale.Fit,
                             )
                         } else {
                             ZoomableImage(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes some issues with video rendering:
- in the timeline the view was unbound, which lead to two unwanted behaviours:
  - the video could extend to occupy a large portion of the timeline while scrolling
  - some video controls like the seek bar were incorrectly positioned, e.g. on the top instead of at the bottom
- in the attachment screen when opening the video, the view was cropped if the video had an aspect ratio > 1.

## Additional notes
<!-- Anything to declare for code review? -->
Nothing to declare.
