### PR TITLE
fix: change settings export default file name; update font scale factors

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/data/FontScale.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/data/FontScale.kt
@@ -56,10 +56,10 @@ fun Float.toFontScale(): FontScale =
 
 private object ReferenceValues {
     const val LARGEST = 1.5f
-    const val LARGER = 1.36f
-    const val LARGE = 1.23f
-    const val NORMAL = 1.1f
-    const val SMALL = 0.96f
-    const val SMALLER = 0.83f
-    const val SMALLEST = 0.7f
+    const val LARGER = 1.38f
+    const val LARGE = 1.27f
+    const val NORMAL = 1.15f
+    const val SMALL = 1.03f
+    const val SMALLER = 0.91f
+    const val SMALLEST = 0.8f
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -83,7 +83,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 private const val SETTINGS_MIME_TYPE = "application/json"
-private const val SETTINGS_FILE_NAME = "raccoon_settings.json"
+private const val SETTINGS_FILE_NAME = "raccoon4lemmy_settings.json"
 
 class AdvancedSettingsScreen : Screen {
     @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR changes the default name of the JSON where settings are going to be exported to. The reason is to make Raccoon for Lemmy settings easily distinguishable from Raccoon for Friendica settings.

## Additional notes
<!-- Anything to declare for code review? -->
Font scale factors were updated because they still "felt wrong". Now the normal factor has the same value of Raccoon for Friendica.
