### PR TITLE
fix: use Fit content scale for videos in timelines

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardVideo.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.VideoPlayer
@@ -44,8 +45,9 @@ fun PostCardVideo(
         modifier =
             modifier
                 .fillMaxWidth()
-                .aspectRatio(16 / 9f).clipToBounds(),
-            contentAlignment = Alignment.Center,
+                .aspectRatio(16 / 9f)
+                .clipToBounds(),
+        contentAlignment = Alignment.Center,
     ) {
         if (blurred) {
             Column(
@@ -75,6 +77,7 @@ fun PostCardVideo(
                 VideoPlayer(
                     modifier = Modifier.fillMaxSize(),
                     url = url,
+                    contentScale = ContentScale.Fit,
                 )
 
                 IconButton(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR makes sure videos do not overlap each other in timelines, using `ScreenResize.FIT` in post cards and `ScreenResize.FILL` only in the attachment detail screen.

## Additional notes
<!-- Anything to declare for code review? -->
By the way, this is the exact same behaviour of videos in [rff#476](https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/476).
