### PR TITLE
fix: add missing insets in modals and below section selectors

### DIFF
--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomModalBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomModalBottomSheet.kt
@@ -61,7 +61,9 @@ fun CustomModalBottomSheet(
             onSelected?.invoke(null)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SelectNumberBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SelectNumberBottomSheet.kt
@@ -89,7 +89,9 @@ fun SelectNumberBottomSheet(
             onSelected?.invoke(null)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SliderBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SliderBottomSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -50,7 +51,9 @@ fun SliderBottomSheet(
             onSelected?.invoke(null)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/SortBottomSheet.kt
@@ -67,7 +67,9 @@ fun SortBottomSheet(
             onSelected?.invoke(null)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             var level by remember { mutableStateOf<SortBottomSheetLevel>(SortBottomSheetLevel.Main) }
             Crossfade(
                 targetState = level,

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -333,6 +333,7 @@ class FilteredContentsScreen(
                     item {
                         if (!uiState.isPostOnly) {
                             SectionSelector(
+                                modifier = Modifier.padding(vertical = Spacing.s),
                                 titles =
                                     listOf(
                                         LocalStrings.current.profileSectionPosts,

--- a/unit/manageaccounts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageaccounts/ManageAccountsBottomSheet.kt
+++ b/unit/manageaccounts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageaccounts/ManageAccountsBottomSheet.kt
@@ -80,7 +80,9 @@ fun ManageAccountsBottomSheet(
             onDismiss?.invoke(false)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,

--- a/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/SelectInstanceBottomSheet.kt
+++ b/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/SelectInstanceBottomSheet.kt
@@ -108,7 +108,9 @@ fun SelectInstanceBottomSheet(
             onSelected?.invoke(null)
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Box(
                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.s),
             ) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR restores a xs bottom padding in modal bottom sheets and inserts an s padding in filtered contents (bookmarks, votes and moderated contents).

