### PR TITLE
fix: remove deprecated constructor for KeyboardOptions

### DIFF
--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditFormattedlInfoDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditFormattedlInfoDialog.kt
@@ -124,7 +124,7 @@ fun EditFormattedInfoDialog(
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Text,
-                                autoCorrect = true,
+                                autoCorrectEnabled = true,
                                 capitalization = KeyboardCapitalization.Sentences,
                             ),
                         onValueChange = { value ->

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditTextualInfoDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditTextualInfoDialog.kt
@@ -85,7 +85,7 @@ fun EditTextualInfoDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Text,
-                        autoCorrect = true,
+                        autoCorrectEnabled = true,
                     ),
                 onValueChange = { value ->
                     textFieldValue = value

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/NumberPickerDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/NumberPickerDialog.kt
@@ -72,7 +72,6 @@ fun NumberPickerDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.NumberPassword,
-                        autoCorrect = true,
                     ),
                 onValueChange = { value ->
                     currentValue = value

--- a/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
+++ b/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
@@ -185,7 +185,7 @@ class BanUserScreen(
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = true,
+                            autoCorrectEnabled = true,
                         ),
                     onValueChange = { value ->
                         model.reduce(BanUserMviModel.Intent.SetText(value))

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -220,7 +220,7 @@ class InboxChatScreen(
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Text,
-                                autoCorrect = true,
+                                autoCorrectEnabled = true,
                                 capitalization = KeyboardCapitalization.Sentences,
                             ),
                         onValueChange = { value ->

--- a/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -422,7 +422,7 @@ class CreateCommentScreen(
                             keyboardOptions =
                                 KeyboardOptions(
                                     keyboardType = KeyboardType.Text,
-                                    autoCorrect = true,
+                                    autoCorrectEnabled = true,
                                     capitalization = KeyboardCapitalization.Sentences,
                                 ),
                             onValueChange = { value ->

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -459,7 +459,7 @@ class CreatePostScreen(
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = true,
+                            autoCorrectEnabled = true,
                             imeAction = ImeAction.Next,
                             capitalization = KeyboardCapitalization.Sentences,
                         ),
@@ -518,7 +518,7 @@ class CreatePostScreen(
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                             imeAction = ImeAction.Next,
                         ),
                     keyboardActions =
@@ -608,7 +608,7 @@ class CreatePostScreen(
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Text,
-                                autoCorrect = true,
+                                autoCorrectEnabled = true,
                                 capitalization = KeyboardCapitalization.Sentences,
                             ),
                         onValueChange = { value ->

--- a/unit/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/login/LoginBottomSheet.kt
+++ b/unit/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/login/LoginBottomSheet.kt
@@ -187,7 +187,6 @@ class LoginBottomSheet : Screen {
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Email,
-                                autoCorrect = false,
                                 imeAction = ImeAction.Next,
                             ),
                         onValueChange = { value ->
@@ -250,7 +249,6 @@ class LoginBottomSheet : Screen {
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Email,
-                                autoCorrect = false,
                                 imeAction = ImeAction.Next,
                             ),
                         onValueChange = { value ->

--- a/unit/moderatewithreason/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/moderatewithreason/ModerateWithReasonScreen.kt
+++ b/unit/moderatewithreason/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/moderatewithreason/ModerateWithReasonScreen.kt
@@ -182,7 +182,7 @@ class ModerateWithReasonScreen(
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = true,
+                            autoCorrectEnabled = true,
                         ),
                     onValueChange = { value ->
                         model.reduce(ModerateWithReasonMviModel.Intent.SetText(value))

--- a/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/dialog/ChangeInstanceDialog.kt
+++ b/unit/selectinstance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/selectinstance/dialog/ChangeInstanceDialog.kt
@@ -75,7 +75,6 @@ internal fun ChangeInstanceDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Email,
-                        autoCorrect = false,
                         imeAction = ImeAction.Next,
                     ),
                 onValueChange = { value ->


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR replaces calls to `KeyboardOptions` constructor with `autoCorrect` parameter in favour of the `autoCorrectEnabled` overload.

## Additional notes
<!-- Anything to declare for code review? -->
This should have been done after updating Compose Multiplatform to 1.7.1.
