### PR TITLE
fix: avoid using nullable types as @InjectedParams

### DIFF
--- a/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
+++ b/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
@@ -71,8 +71,8 @@ class BanUserScreen(
                     userId,
                     communityId,
                     newValue,
-                    postId,
-                    commentId,
+                    postId ?: 0L,
+                    commentId ?: 0L,
                 )
             }
         val uiState by model.uiState.collectAsState()

--- a/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserViewModel.kt
+++ b/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserViewModel.kt
@@ -15,15 +15,15 @@ class BanUserViewModel(
     @InjectedParam private val userId: Long,
     @InjectedParam private val communityId: Long,
     @InjectedParam private val newValue: Boolean,
-    @InjectedParam private val postId: Long?,
-    @InjectedParam private val commentId: Long?,
+    @InjectedParam private val postId: Long,
+    @InjectedParam private val commentId: Long,
     private val identityRepository: IdentityRepository,
     private val communityRepository: CommunityRepository,
     private val notificationCenter: NotificationCenter,
-) : BanUserMviModel,
-    DefaultMviModel<BanUserMviModel.Intent, BanUserMviModel.UiState, BanUserMviModel.Effect>(
+) : DefaultMviModel<BanUserMviModel.Intent, BanUserMviModel.UiState, BanUserMviModel.Effect>(
         initialState = BanUserMviModel.UiState(),
-    ) {
+    ),
+    BanUserMviModel {
     init {
         screenModelScope.launch {
             updateState {
@@ -92,7 +92,7 @@ class BanUserViewModel(
                         removeData = removeData,
                     )
                 if (newUser != null) {
-                    postId?.also {
+                    postId.takeIf { it != 0L }?.also {
                         val evt =
                             NotificationCenterEvent.UserBannedPost(
                                 postId = it,
@@ -100,7 +100,7 @@ class BanUserViewModel(
                             )
                         notificationCenter.send(evt)
                     }
-                    commentId?.also {
+                    commentId.takeIf { it != 0L }?.also {
                         val evt =
                             NotificationCenterEvent.UserBannedComment(
                                 commentId = it,

--- a/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -1,6 +1,5 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.createcomment
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,16 +83,16 @@ class CreateCommentScreen(
     private val editedCommentId: Long? = null,
     private val initialText: String? = null,
 ) : Screen {
-    @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
         val model =
             getScreenModel<CreateCommentMviModel> {
                 parametersOf(
-                    originalPostId,
-                    originalCommentId,
-                    editedCommentId,
-                    draftId,
+                    originalPostId ?: 0L,
+                    originalCommentId ?: 0L,
+                    editedCommentId ?: 0L,
+                    draftId ?: 0L,
                 )
             }
         val uiState by model.uiState.collectAsState()

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -101,7 +101,11 @@ class CreatePostScreen(
     override fun Content() {
         val model =
             getScreenModel<CreatePostMviModel> {
-                parametersOf(editedPostId, crossPostId, draftId)
+                parametersOf(
+                    editedPostId ?: 0L,
+                    crossPostId ?: 0L,
+                    draftId ?: 0L,
+                )
             }
         val uiState by model.uiState.collectAsState()
         val snackbarHostState = remember { SnackbarHostState() }

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
@@ -32,9 +32,9 @@ import org.koin.core.annotation.InjectedParam
 
 @Factory(binds = [CreatePostMviModel::class])
 class CreatePostViewModel(
-    @InjectedParam private val editedPostId: Long?,
-    @InjectedParam private val crossPostId: Long?,
-    @InjectedParam private val draftId: Long?,
+    @InjectedParam private val editedPostId: Long,
+    @InjectedParam private val crossPostId: Long,
+    @InjectedParam private val draftId: Long,
     private val identityRepository: IdentityRepository,
     private val postRepository: PostRepository,
     private val mediaRepository: MediaRepository,
@@ -55,11 +55,11 @@ class CreatePostViewModel(
     init {
         screenModelScope.launch {
             val editedPost =
-                editedPostId?.let {
+                editedPostId.takeIf { it != 0L }?.let {
                     itemCache.getPost(it)
                 }
             val crossPost =
-                crossPostId?.let {
+                crossPostId.takeIf { it != 0L }?.let {
                     itemCache.getPost(it)
                 }
             updateState { it.copy(editedPost = editedPost, crossPost = crossPost) }
@@ -304,7 +304,7 @@ class CreatePostViewModel(
             try {
                 val auth = identityRepository.authToken.value.orEmpty()
                 when {
-                    editedPostId != null -> {
+                    editedPostId != 0L -> {
                         postRepository.edit(
                             postId = editedPostId,
                             title = title,
@@ -328,7 +328,7 @@ class CreatePostViewModel(
                         )
                     }
                 }
-                if (draftId != null) {
+                if (draftId != 0L) {
                     deleteDraft()
                 }
                 emitEffect(CreatePostMviModel.Effect.Success)
@@ -374,7 +374,7 @@ class CreatePostViewModel(
                     date = epochMillis(),
                     reference = community?.name,
                 )
-            if (draftId == null) {
+            if (draftId == 0L) {
                 draftRepository.create(
                     model = draft,
                     accountId = accountId,
@@ -388,8 +388,8 @@ class CreatePostViewModel(
     }
 
     private suspend fun deleteDraft() {
-        draftId?.also { id ->
-            draftRepository.delete(id)
+        if (draftId != 0L) {
+            draftRepository.delete(draftId)
             notificationCenter.send(NotificationCenterEvent.DraftDeleted)
         }
     }

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
@@ -67,7 +67,7 @@ class ModlogScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model = getScreenModel<ModlogMviModel> { parametersOf(communityId) }
+        val model = getScreenModel<ModlogMviModel> { parametersOf(communityId ?: 0L) }
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogViewModel.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogViewModel.kt
@@ -14,7 +14,7 @@ import org.koin.core.annotation.InjectedParam
 
 @Factory(binds = [ModlogMviModel::class])
 class ModlogViewModel(
-    @InjectedParam private val communityId: Long?,
+    @InjectedParam private val communityId: Long,
     private val themeRepository: ThemeRepository,
     private val identityRepository: IdentityRepository,
     private val modlogRepository: ModlogRepository,
@@ -87,7 +87,7 @@ class ModlogViewModel(
             val itemList =
                 modlogRepository.getItems(
                     auth = auth,
-                    communityId = communityId,
+                    communityId = communityId.takeIf { it != 0L },
                     page = currentPage,
                 )
             val itemsToAdd = itemList.orEmpty()

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -163,7 +163,7 @@ class PostDetailScreen(
                     parametersOf(
                         postId,
                         otherInstance,
-                        highlightCommentId,
+                        highlightCommentId ?: 0L,
                         isMod,
                     )
                 },

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -46,7 +46,7 @@ import org.koin.core.annotation.InjectedParam
 class PostDetailViewModel(
     @InjectedParam postId: Long,
     @InjectedParam private val otherInstance: String,
-    @InjectedParam private val highlightCommentId: Long?,
+    @InjectedParam private val highlightCommentId: Long,
     @InjectedParam private val isModerator: Boolean,
     private val identityRepository: IdentityRepository,
     private val apiConfigurationRepository: ApiConfigurationRepository,
@@ -241,7 +241,7 @@ class PostDetailViewModel(
                 )
             }
 
-            if (highlightCommentId != null) {
+            if (highlightCommentId != 0L) {
                 val comment =
                     commentRepository.getBy(
                         id = highlightCommentId,

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -82,7 +82,7 @@ class ReportListScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model = getScreenModel<ReportListMviModel> { parametersOf(communityId) }
+        val model = getScreenModel<ReportListMviModel> { parametersOf(communityId ?: 0L) }
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListViewModel.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListViewModel.kt
@@ -23,7 +23,7 @@ import org.koin.core.annotation.InjectedParam
 
 @Factory(binds = [ReportListMviModel::class])
 class ReportListViewModel(
-    @InjectedParam private val communityId: Long?,
+    @InjectedParam private val communityId: Long,
     private val identityRepository: IdentityRepository,
     private val postRepository: PostRepository,
     private val commentRepository: CommentRepository,
@@ -151,7 +151,7 @@ class ReportListViewModel(
                     async {
                         postRepository.getReports(
                             auth = auth,
-                            communityId = communityId,
+                            communityId = communityId.takeIf { it != 0L },
                             page = page,
                             unresolvedOnly = unresolvedOnly,
                         )
@@ -164,7 +164,7 @@ class ReportListViewModel(
                             commentRepository
                                 .getReports(
                                     auth = auth,
-                                    communityId = communityId,
+                                    communityId = communityId.takeIf { it != 0L },
                                     page = 1,
                                     unresolvedOnly = unresolvedOnly,
                                 ).orEmpty()
@@ -197,7 +197,7 @@ class ReportListViewModel(
             val itemList =
                 commentRepository.getReports(
                     auth = auth,
-                    communityId = communityId,
+                    communityId = communityId.takeIf { it != 0L },
                     page = page,
                     unresolvedOnly = unresolvedOnly,
                 )

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -134,7 +134,12 @@ class UserDetailScreen(
         val model =
             getScreenModel<UserDetailMviModel>(
                 tag = userId.toString(),
-                parameters = { parametersOf(userId, otherInstance) },
+                parameters = {
+                    parametersOf(
+                        userId,
+                        otherInstance,
+                    )
+                },
             )
         val uiState by model.uiState.collectAsState()
         val lazyListState = rememberLazyListState()

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -46,7 +46,7 @@ import org.koin.core.annotation.InjectedParam
 @Factory(binds = [UserDetailMviModel::class])
 class UserDetailViewModel(
     @InjectedParam private val userId: Long,
-    @InjectedParam private val otherInstance: String = "",
+    @InjectedParam private val otherInstance: String,
     private val identityRepository: IdentityRepository,
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val postPaginationManager: PostPaginationManager,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR solves a bug introduces after migrating the whole project to Koin with annotations. Apparently, nullable types are not supported so if an `@InjectedParam` had a null value at runtime, its actual value is "not defined" (can be the first non-null values of the other params or result in an error).

Curiously enough, when using the DSL everything worked perfectly, so it's definitely something related to Koin Annotations 2.0.0-Beta2.

## Additional notes
<!-- Anything to declare for code review? -->
The solution to this was always pass non-null values, marking the case when a value is missing with a sentinel (e.g. `0L` for IDs, etc.).
