### PR TITLE
chore(build): apply convention plugins to :core:persistence

### DIFF
--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureAndroidTest.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureAndroidTest.kt
@@ -1,0 +1,27 @@
+package extensions
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import utils.dependency
+import utils.libs
+
+internal fun Project.configureAndroidTest(extension: KotlinMultiplatformExtension) {
+    extension.apply {
+        sourceSets.apply {
+            androidUnitTest {
+                dependencies {
+                    implementation(libs.findLibrary("kotlinx-coroutines-test").dependency)
+                    implementation(kotlin("test-junit"))
+                    implementation(libs.findLibrary("mockk").dependency)
+                    implementation(libs.findLibrary("turbine").dependency)
+                    implementation(project(":core:testutils"))
+                }
+            }
+            commonTest {
+                dependencies {
+                    implementation(kotlin("test"))
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/plugins/AndroidTestPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/AndroidTestPlugin.kt
@@ -1,35 +1,16 @@
 package plugins
 
+import extensions.configureAndroidTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.kotlin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import utils.dependency
-import utils.libs
 
 class AndroidTestPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit =
         with(target) {
             extensions.configure(
                 KotlinMultiplatformExtension::class.java,
-            ) {
-                sourceSets.apply {
-                    androidUnitTest {
-                        dependencies {
-                            implementation(libs.findLibrary("kotlinx-coroutines-test").dependency)
-                            implementation(kotlin("test-junit"))
-                            implementation(libs.findLibrary("mockk").dependency)
-                            implementation(libs.findLibrary("turbine").dependency)
-                            implementation(project(":core:testutils"))
-                        }
-                    }
-                    commonTest {
-                        dependencies {
-                            implementation(kotlin("test"))
-                        }
-                    }
-                }
-            }
+                ::configureAndroidTest,
+            )
         }
 }

--- a/core/architecture/testutils/build.gradle.kts
+++ b/core/architecture/testutils/build.gradle.kts
@@ -1,29 +1,8 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.library)
+    id("com.livefast.eattrash.kotlinMultiplatform")
 }
 
-@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-    applyDefaultHierarchyTemplate()
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-        }
-    }
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64(),
-    ).forEach {
-        it.binaries.framework {
-            baseName = "core.architecture.testutils"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         val commonMain by getting
         val androidMain by getting {
@@ -33,19 +12,5 @@ kotlin {
                 implementation(kotlin("test-junit"))
             }
         }
-    }
-}
-
-android {
-    namespace = "com.livefast.eattrash.raccoonforlemmy.core.architecture.testutils"
-    compileSdk =
-        libs.versions.android.compileSdk
-            .get()
-            .toInt()
-    defaultConfig {
-        minSdk =
-            libs.versions.android.minSdk
-                .get()
-                .toInt()
     }
 }

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -1,39 +1,14 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.library)
+    id("com.livefast.eattrash.kotlinMultiplatform")
     alias(libs.plugins.sqldelight)
-    alias(libs.plugins.jetbrains.compose)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.kotlinx.serialization)
+    id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.koinWithKsp")
+    id("com.livefast.eattrash.serialization")
+    id("com.livefast.eattrash.androidTest")
     alias(libs.plugins.kotlinx.kover)
-    alias(libs.plugins.ksp)
 }
 
 kotlin {
-    applyDefaultHierarchyTemplate()
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-        }
-    }
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64(),
-    ).forEach {
-        it.binaries.framework {
-            baseName = "core.persistence"
-            isStatic = true
-        }
-    }
-
-    compilerOptions {
-        freeCompilerArgs.add("-Xexpect-actual-classes")
-    }
-
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -48,10 +23,6 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.material)
-                implementation(compose.materialIconsExtended)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization.json)
 
@@ -64,36 +35,6 @@ kotlin {
                 implementation(projects.core.utils)
             }
         }
-        val androidUnitTest by getting {
-            dependencies {
-                implementation(libs.kotlinx.coroutines.test)
-                implementation(kotlin("test-junit"))
-                implementation(libs.mockk)
-                implementation(projects.core.testutils)
-            }
-        }
-    }
-}
-
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp)
-    add("kspAndroid", libs.koin.ksp)
-    add("kspIosX64", libs.koin.ksp)
-    add("kspIosArm64", libs.koin.ksp)
-    add("kspIosSimulatorArm64", libs.koin.ksp)
-}
-
-android {
-    namespace = "com.livefast.eattrash.raccoonforlemmy.core.persistence"
-    compileSdk =
-        libs.versions.android.compileSdk
-            .get()
-            .toInt()
-    defaultConfig {
-        minSdk =
-            libs.versions.android.minSdk
-                .get()
-                .toInt()
     }
 }
 
@@ -105,18 +46,4 @@ sqldelight {
         }
     }
     linkSqlite = true
-}
-
-ksp {
-    arg("KOIN_DEFAULT_MODULE", "false")
-}
-
-kotlin.sourceSets.commonMain {
-    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
-}
-
-tasks.withType(KotlinCompilationTask::class.java).configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR continues the work of #143 and #144 and applies the convention plugins to `:core:persistence` and `:core:architecture:testutils`.

Moreover it refactors `AndroidTestPlugin` to have the same structure of the other plugins and be more maintainable.

## Additional notes
<!-- Anything to declare for code review? -->
I didn't manage to do it yesterday but I was in a hurry, today I said to myself "I'll have a more thorough look at it with more time" and it worked. Probably sqldelight plugin is picky on the order in which it is applied with respect to the other ones.
