### PR TITLE
fix: open image detail with high res URL instead of thumbnail

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -599,11 +599,13 @@ private fun ExtendedPost(
                         blurred = blurNsfw && post.nsfw,
                         contentScale = if (fullHeightImage) ContentScale.FillWidth else ContentScale.Crop,
                         maxHeight = if (fullHeightImage) Dp.Unspecified else EXTENDED_POST_MAX_HEIGHT,
-                        onImageClick = { url ->
+                        onImageClick = {
                             if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
                                 uriHandler.openUri(postLinkUrl)
                             } else {
-                                onOpenImage?.invoke(url)
+                                val urlToOpen =
+                                    post.url?.takeIf { it.looksLikeAnImage } ?: post.imageUrl
+                                onOpenImage?.invoke(urlToOpen)
                             }
                         },
                         onDoubleClick = onDoubleClick,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes the image detail opening behaviour: if the URL of the post is an image, it is the high-resolution image URL which should be opened instead of the thumbnail one.
