### PR TITLE
fix: use different error message if autofill title empty

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/DefaultStrings.kt
@@ -447,4 +447,5 @@ internal open class DefaultStrings : Strings {
     }
 
     override val settingsAboutMatrix = "Join Matrix room"
+    override val messageNoResult = "Oops… no result found!"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/ItStrings.kt
@@ -462,4 +462,5 @@ internal val ItStrings =
             }
 
         override val settingsAboutMatrix = "Entra nella room Matrix"
+        override val messageNoResult = "Ops… nessun risultato trovato!"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/messages/Strings.kt
@@ -441,6 +441,7 @@ interface Strings {
     fun inboxNotificationContent(count: Int): String
 
     val settingsAboutMatrix: String
+    val messageNoResult: String
 }
 
 object Locales {

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostMviModel.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostMviModel.kt
@@ -17,15 +17,25 @@ interface CreatePostMviModel :
     MviModel<CreatePostMviModel.Intent, CreatePostMviModel.UiState, CreatePostMviModel.Effect>,
     ScreenModel {
     sealed interface Intent {
-        data class SetCommunity(val value: CommunityModel) : Intent
+        data class SetCommunity(
+            val value: CommunityModel,
+        ) : Intent
 
-        data class SetTitle(val value: String) : Intent
+        data class SetTitle(
+            val value: String,
+        ) : Intent
 
-        data class SetUrl(val value: String) : Intent
+        data class SetUrl(
+            val value: String,
+        ) : Intent
 
-        data class ChangeNsfw(val value: Boolean) : Intent
+        data class ChangeNsfw(
+            val value: Boolean,
+        ) : Intent
 
-        data class ImageSelected(val value: ByteArray) : Intent {
+        data class ImageSelected(
+            val value: ByteArray,
+        ) : Intent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other == null || this::class != other::class) return false
@@ -35,12 +45,12 @@ interface CreatePostMviModel :
                 return value.contentEquals(other.value)
             }
 
-            override fun hashCode(): Int {
-                return value.contentHashCode()
-            }
+            override fun hashCode(): Int = value.contentHashCode()
         }
 
-        data class InsertImageInBody(val value: ByteArray) : Intent {
+        data class InsertImageInBody(
+            val value: ByteArray,
+        ) : Intent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other == null || this::class != other::class) return false
@@ -50,16 +60,20 @@ interface CreatePostMviModel :
                 return value.contentEquals(other.value)
             }
 
-            override fun hashCode(): Int {
-                return value.contentHashCode()
-            }
+            override fun hashCode(): Int = value.contentHashCode()
         }
 
-        data class ChangeSection(val value: CreatePostSection) : Intent
+        data class ChangeSection(
+            val value: CreatePostSection,
+        ) : Intent
 
-        data class ChangeLanguage(val value: Long?) : Intent
+        data class ChangeLanguage(
+            val value: Long?,
+        ) : Intent
 
-        data class ChangeBodyValue(val value: TextFieldValue) : Intent
+        data class ChangeBodyValue(
+            val value: TextFieldValue,
+        ) : Intent
 
         data object Send : Intent
 
@@ -100,10 +114,14 @@ interface CreatePostMviModel :
     sealed interface Effect {
         data object Success : Effect
 
-        data class Failure(val message: String?) : Effect
+        data class Failure(
+            val message: String?,
+        ) : Effect
 
         data object DraftSaved : Effect
 
-        data object AutoFillFailed : Effect
+        data object AutoFillError : Effect
+
+        data object AutoFillEmpty : Effect
     }
 }

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -110,6 +110,7 @@ class CreatePostScreen(
         val uiState by model.uiState.collectAsState()
         val snackbarHostState = remember { SnackbarHostState() }
         val genericError = LocalStrings.current.messageGenericError
+        val autofillEmpty = LocalStrings.current.messageNoResult
         val notificationCenter = remember { getNotificationCenter() }
         val galleryHelper = remember { getGalleryHelper() }
         val crossPostText = LocalStrings.current.createPostCrossPostText
@@ -204,9 +205,8 @@ class CreatePostScreen(
             model.effects
                 .onEach { effect ->
                     when (effect) {
-                        is CreatePostMviModel.Effect.Failure -> {
+                        is CreatePostMviModel.Effect.Failure ->
                             snackbarHostState.showSnackbar(effect.message ?: genericError)
-                        }
 
                         CreatePostMviModel.Effect.Success -> {
                             notificationCenter.send(
@@ -217,9 +217,11 @@ class CreatePostScreen(
 
                         CreatePostMviModel.Effect.DraftSaved -> navigationCoordinator.popScreen()
 
-                        CreatePostMviModel.Effect.AutoFillFailed -> {
+                        CreatePostMviModel.Effect.AutoFillError ->
                             snackbarHostState.showSnackbar(genericError)
-                        }
+
+                        CreatePostMviModel.Effect.AutoFillEmpty ->
+                            snackbarHostState.showSnackbar(autofillEmpty)
                     }
                 }.launchIn(this)
         }

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostViewModel.kt
@@ -399,12 +399,12 @@ class CreatePostViewModel(
         screenModelScope.launch {
             updateState { it.copy(loading = true) }
             val metadata = siteRepository.getMetadata(url)
-            val suggestedTitle = metadata?.title.takeUnless { it.isNullOrBlank() }
             updateState { it.copy(loading = false) }
-            if (suggestedTitle == null) {
-                emitEffect(CreatePostMviModel.Effect.AutoFillFailed)
-            } else {
-                updateState { it.copy(title = suggestedTitle) }
+
+            when {
+                metadata == null -> emitEffect(CreatePostMviModel.Effect.AutoFillError)
+                metadata.title.isEmpty() -> emitEffect(CreatePostMviModel.Effect.AutoFillEmpty)
+                else -> updateState { it.copy(title = metadata.title) }
             }
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR uses different messages for when it is not possible to autocomplete a post title using the GET `api/v3/post/site_metadata` endpoint.

There are two possible outcomes:
- the network call is not successful -> in this case the generic message (as-is) is valid;
- the network call is successful but the metadata it returns have an empty title -> new informative message.

