### PR TITLE
refactor(l10n): move language names to resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,14 +166,46 @@ another letter set for the region `YY` (e.g. `pt_BR` for Brazilian Portuguese or
 Portuguese). If you only have to use the `xx` part, please ignore the `yy` indication in the rest
 of the explanation contained in this paragraph.
 
-Create a directory called `values-xx-rYY` in `shared/commonMain/composeResources` with a file named
+(1) Create a new string element in the `shared/commonMain/composeResources/values/strings.xml`:
+
+```
+    <string name="language_xx_yy" translatable="false">XXXXXX</string>
+```
+
+where `XXXXXX` is the name of the language in the language itself (endonym).
+
+(2) Create a directory called `values-xx-rYY` in `shared/commonMain/composeResources` with a file
+named
 `strings.xml` in it. Use `shared/commonMain/composeResources/values/strings.xml` as a reference in
 case of doubts. This file will be taken care of by the compose Gradle plugin to generate resources.
 
 This is an XML file, it must be valid and well-formed so please remember to use entities for illegal
 characters (e.g. `&` should be represented as `&amp;`).
 
-Afterwards, edit [
+(3) When you are done modifying the XML files, please recompile the project to allow code generation
+to create the corresponding Compose resources.
+
+(4) Edit [
+`Strings.kt`](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt)
+and add a new property
+
+```
+     val languageXxYy: String @Composable get
+```
+
+(5) )n [
+`SharedStrings.kt`](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt)
+add the following lines
+
+```
+    override val languageXxYy: String
+        @Composable get() = stringResource(Res.string.language_xx_yy)
+```
+
+Be careful: the extension on `Res.string` will only be generated after you have recompiled as per
+step (3) above.
+
+(6) Edit [
 `Locales.kt`](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Locales.kt)
 with the following modifications:
 
@@ -190,12 +222,10 @@ object Locales {
 }
 ```
 
-Finally, in [
+(7) In [
 `Extensions.kt`](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Extensions.kt)
 add your flag and language name in `toLanguageFlag()` and `toLanguageName()` respectively in order
 to map the language code to the desired values.
-
-That's it! 🎉
 
 ### 3.5 Submit a pull request
 

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Extensions.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Extensions.kt
@@ -6,20 +6,21 @@ import androidx.compose.ui.unit.LayoutDirection
 @Composable
 fun String.toLanguageName() =
     when (this) {
-        Locales.DE -> "Deutsch"
-        Locales.GA -> "Gaeilge"
-        Locales.ES -> "Español"
-        Locales.FI -> "Suomi"
-        Locales.FR -> "Français"
-        Locales.IT -> "Italiano"
-        Locales.PL -> "Polski"
-        Locales.PT -> "Português"
-        Locales.PT_BR -> "Português (Brazil)"
-        Locales.UA -> "Українська"
-        Locales.ZH_CN -> "中文"
-        Locales.ZH_TW -> "正體中文"
-        Locales.ZH_HK -> "廣東話"
-        else -> "English"
+        Locales.DE -> LocalStrings.current.languageDe
+        Locales.GA -> LocalStrings.current.languageGa
+        Locales.ES -> LocalStrings.current.languageEs
+        Locales.FI -> LocalStrings.current.languageFi
+        Locales.FR -> LocalStrings.current.languageFr
+        Locales.IT -> LocalStrings.current.languageIt
+        Locales.PL -> LocalStrings.current.languagePl
+        Locales.PT -> LocalStrings.current.languagePt
+        Locales.PT_BR -> LocalStrings.current.languagePtBr
+        Locales.UA -> LocalStrings.current.languageUa
+        Locales.ZH_CN -> LocalStrings.current.languageZhCn
+        Locales.ZH_HK -> LocalStrings.current.languageZhHk
+        Locales.ZH_TW -> LocalStrings.current.languageZhTw
+        Locales.EN -> LocalStrings.current.languageEn
+        else -> ""
     }
 
 @Composable

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
@@ -96,7 +96,20 @@ interface Strings {
     val inboxSectionReplies: String @Composable get
     val instanceDetailCommunities: String @Composable get
     val instanceDetailTitle: String @Composable get
-    val lang: String @Composable get
+    val languageDe: String @Composable get
+    val languageEn: String @Composable get
+    val languageEs: String @Composable get
+    val languageFi: String @Composable get
+    val languageFr: String @Composable get
+    val languageGa: String @Composable get
+    val languageIt: String @Composable get
+    val languagePl: String @Composable get
+    val languagePt: String @Composable get
+    val languagePtBr: String @Composable get
+    val languageUa: String @Composable get
+    val languageZhCn: String @Composable get
+    val languageZhHk: String @Composable get
+    val languageZhTw: String @Composable get
     val loginFieldInstanceName: String @Composable get
     val loginFieldLabelOptional: String @Composable get
     val loginFieldPassword: String @Composable get

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Antworten</string>
     <string name="instance_detail_communities">Communitys</string>
     <string name="instance_detail_title">Instanz:</string>
-    <string name="lang">en</string>
     <string name="login_field_instance_name">Instanzname</string>
     <string name="login_field_label_optional">(optional)</string>
     <string name="login_field_password">Passwort</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Respuestas</string>
     <string name="instance_detail_communities">Comunidades</string>
     <string name="instance_detail_title">Instancia:</string>
-    <string name="lang">es</string>
     <string name="login_field_instance_name">Nombre de instancia</string>
     <string name="login_field_label_optional">(opcional)</string>
     <string name="login_field_password">Contraseña</string>

--- a/shared/src/commonMain/composeResources/values-fi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fi/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Vastausta</string>
     <string name="instance_detail_communities">Yhteisöt</string>
     <string name="instance_detail_title">Instanssi:</string>
-    <string name="lang">fi</string>
     <string name="login_field_instance_name">Esiintymän nimi</string>
     <string name="login_field_label_optional">(lisävaruste)</string>
     <string name="login_field_password">Salasana</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Réponses</string>
     <string name="instance_detail_communities">Communautés</string>
     <string name="instance_detail_title">Instance :</string>
-    <string name="lang">fr</string>
     <string name="login_field_instance_name">Nom de l'instance</string>
     <string name="login_field_label_optional">(optionnel)</string>
     <string name="login_field_password">Mot de passe</string>

--- a/shared/src/commonMain/composeResources/values-ga/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ga/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Freagraí</string>
     <string name="instance_detail_communities">An Coimisiún Eorpach</string>
     <string name="instance_detail_title">Ásc:</string>
-    <string name="lang">ga</string>
     <string name="login_field_instance_name">Ainm cás</string>
     <string name="login_field_label_optional">(roghnach)</string>
     <string name="login_field_password">Pasfhocal</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Risposte</string>
     <string name="instance_detail_communities">Comunità</string>
     <string name="instance_detail_title">Istanza:</string>
-    <string name="lang">it</string>
     <string name="login_field_instance_name">Nome istanza</string>
     <string name="login_field_label_optional">(opzionale)</string>
     <string name="login_field_password">Password</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Odpowiedzi</string>
     <string name="instance_detail_communities">Społeczności</string>
     <string name="instance_detail_title">Instancja:</string>
-    <string name="lang">pl</string>
     <string name="login_field_instance_name">Nazwa instancji</string>
     <string name="login_field_label_optional">(opcjonalny)</string>
     <string name="login_field_password">Hasło</string>

--- a/shared/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Respostas</string>
     <string name="instance_detail_communities">Comunidades</string>
     <string name="instance_detail_title">Instância:</string>
-    <string name="lang">pt_rBR</string>
     <string name="login_field_instance_name">Nome da instância</string>
     <string name="login_field_label_optional">(opcional)</string>
     <string name="login_field_password">Senha</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Respostas</string>
     <string name="instance_detail_communities">Comunidades</string>
     <string name="instance_detail_title">Instância:</string>
-    <string name="lang">pt</string>
     <string name="login_field_instance_name">Nome da instância</string>
     <string name="login_field_label_optional">(optional)</string>
     <string name="login_field_password">Palavra-passe</string>

--- a/shared/src/commonMain/composeResources/values-ua/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ua/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">Відповіді</string>
     <string name="instance_detail_communities">Спільноти</string>
     <string name="instance_detail_title">примірник:</string>
-    <string name="lang">uk</string>
     <string name="login_field_instance_name">Назва екземпляра</string>
     <string name="login_field_label_optional">(необов\'язковий)</string>
     <string name="login_field_password">Пароль</string>

--- a/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -99,7 +99,6 @@
     <string name="inbox_section_replies">回复</string>
     <string name="instance_detail_communities">社区</string>
     <string name="instance_detail_title">实例:</string>
-    <string name="lang">zh_CN</string>
     <string name="login_field_instance_name">实例名称</string>
     <string name="login_field_label_optional">(可选)</string>
     <string name="login_field_password">密码</string>

--- a/shared/src/commonMain/composeResources/values-zh-rHK/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rHK/strings.xml
@@ -150,7 +150,6 @@
     <string name="inbox_section_replies">回覆</string>
     <string name="instance_detail_communities">社區</string>
     <string name="instance_detail_title">網站:</string>
-    <string name="lang">zh_HK</string>
     <string name="login_field_instance_name">網站名稱</string>
     <string name="login_field_label_optional">(唔一定要)</string>
     <string name="login_field_password">密碼</string>

--- a/shared/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -151,7 +151,6 @@
     <string name="inbox_section_replies">回覆</string>
     <string name="instance_detail_communities">社區</string>
     <string name="instance_detail_title">網站:</string>
-    <string name="lang">zh_TW</string>
     <string name="login_field_instance_name">網站名稱</string>
     <string name="login_field_label_optional">(可選)</string>
     <string name="login_field_password">密碼</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -152,7 +152,20 @@
     <string name="inbox_section_replies">Replies</string>
     <string name="instance_detail_communities">Communities</string>
     <string name="instance_detail_title">Instance:</string>
-    <string name="lang">en</string>
+    <string name="language_de" translatable="false">Deutsch</string>
+    <string name="language_en" translatable="false">English</string>
+    <string name="language_es" translatable="false">Español</string>
+    <string name="language_fi" translatable="false">Suomi</string>
+    <string name="language_fr" translatable="false">Français</string>
+    <string name="language_ga" translatable="false">Gaeilge</string>
+    <string name="language_it" translatable="false">Italiano</string>
+    <string name="language_pl" translatable="false">Polski</string>
+    <string name="language_pt" translatable="false">Português</string>
+    <string name="language_pt_br" translatable="false">Português (Brazil)</string>
+    <string name="language_ua" translatable="false">Українська</string>
+    <string name="language_zh_cn" translatable="false">中文</string>
+    <string name="language_zh_hk" translatable="false">廣東話</string>
+    <string name="language_zh_tw" translatable="false">正體中文</string>
     <string name="login_field_instance_name">Instance name</string>
     <string name="login_field_label_optional">(optional)</string>
     <string name="login_field_password">Password</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
@@ -160,7 +160,20 @@ import raccoonforlemmy.shared.generated.resources.inbox_section_messages
 import raccoonforlemmy.shared.generated.resources.inbox_section_replies
 import raccoonforlemmy.shared.generated.resources.instance_detail_communities
 import raccoonforlemmy.shared.generated.resources.instance_detail_title
-import raccoonforlemmy.shared.generated.resources.lang
+import raccoonforlemmy.shared.generated.resources.language_de
+import raccoonforlemmy.shared.generated.resources.language_en
+import raccoonforlemmy.shared.generated.resources.language_es
+import raccoonforlemmy.shared.generated.resources.language_fi
+import raccoonforlemmy.shared.generated.resources.language_fr
+import raccoonforlemmy.shared.generated.resources.language_ga
+import raccoonforlemmy.shared.generated.resources.language_it
+import raccoonforlemmy.shared.generated.resources.language_pl
+import raccoonforlemmy.shared.generated.resources.language_pt
+import raccoonforlemmy.shared.generated.resources.language_pt_br
+import raccoonforlemmy.shared.generated.resources.language_ua
+import raccoonforlemmy.shared.generated.resources.language_zh_cn
+import raccoonforlemmy.shared.generated.resources.language_zh_hk
+import raccoonforlemmy.shared.generated.resources.language_zh_tw
 import raccoonforlemmy.shared.generated.resources.login_field_instance_name
 import raccoonforlemmy.shared.generated.resources.login_field_label_optional
 import raccoonforlemmy.shared.generated.resources.login_field_password
@@ -629,8 +642,34 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.instance_detail_communities)
     override val instanceDetailTitle: String
         @Composable get() = stringResource(Res.string.instance_detail_title)
-    override val lang: String
-        @Composable get() = stringResource(Res.string.lang)
+    override val languageDe: String
+        @Composable get() = stringResource(Res.string.language_de)
+    override val languageEn: String
+        @Composable get() = stringResource(Res.string.language_en)
+    override val languageEs: String
+        @Composable get() = stringResource(Res.string.language_es)
+    override val languageFi: String
+        @Composable get() = stringResource(Res.string.language_fi)
+    override val languageFr: String
+        @Composable get() = stringResource(Res.string.language_fr)
+    override val languageGa: String
+        @Composable get() = stringResource(Res.string.language_ga)
+    override val languageIt: String
+        @Composable get() = stringResource(Res.string.language_it)
+    override val languagePl: String
+        @Composable get() = stringResource(Res.string.language_pl)
+    override val languagePt: String
+        @Composable get() = stringResource(Res.string.language_pt)
+    override val languagePtBr: String
+        @Composable get() = stringResource(Res.string.language_pt_br)
+    override val languageUa: String
+        @Composable get() = stringResource(Res.string.language_ua)
+    override val languageZhCn: String
+        @Composable get() = stringResource(Res.string.language_zh_cn)
+    override val languageZhHk: String
+        @Composable get() = stringResource(Res.string.language_zh_hk)
+    override val languageZhTw: String
+        @Composable get() = stringResource(Res.string.language_zh_tw)
     override val loginFieldInstanceName: String
         @Composable get() = stringResource(Res.string.login_field_instance_name)
     override val loginFieldLabelOptional: String


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR moves language names to resources as untranslatable messages. Moreover the `lang` string was useless and could be removed.
