### PR TITLE
fix: injected params in view models

### DIFF
--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -102,7 +102,7 @@ class MultiCommunityScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model: MultiCommunityMviModel = rememberScreenModel(communityId)
+        val model: MultiCommunityMviModel = rememberScreenModel(arg = communityId)
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/editor/MultiCommunityEditorScreen.kt
@@ -69,7 +69,7 @@ class MultiCommunityEditorScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model: MultiCommunityEditorMviModel = rememberScreenModel(communityId)
+        val model: MultiCommunityEditorMviModel = rememberScreenModel(arg = communityId ?: 0)
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
 

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -81,7 +81,7 @@ class ReportListScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model: ReportListMviModel = rememberScreenModel(communityId ?: 0L)
+        val model: ReportListMviModel = rememberScreenModel(arg = communityId ?: 0L)
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
@@ -62,7 +62,7 @@ class ZoomableImageScreen(
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val model: ZoomableImageMviModel = rememberScreenModel(url)
+        val model: ZoomableImageMviModel = rememberScreenModel(arg = url)
         val uiState by model.uiState.collectAsState()
         val snackbarHostState = remember { SnackbarHostState() }
         val successMessage = LocalStrings.current.messageOperationSuccessful


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a bug due to which instantiating viewmodels with injected args failed due to the wrong overload of `rememberScreenModel` being used.

## Additional notes
<!-- Anything to declare for code review? -->
This bug was introduced in #181 due to having to migrate everything manually.
