### PR TITLE
fix: remove escapes for apostrophes

### DIFF
--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_zombie_mode_scroll_amount">Desplazamiento del modo zombie</string>
     <string name="share_mode_file">Compartir como archivo</string>
     <string name="share_mode_url">Compartir como URL</string>
-    <string name="sidebar_not_logged_message">¡Bienvenido a Raccoon!\n\nEn modo anónimo, usa el botón desplegable (▼) de arriba para cambiar de instancia.\n\nPuedes iniciar sesión en tu instancia en cualquier momento desde la pestaña \'Perfil\'.\n\n¡Disfruta de Lemmy!</string>
+    <string name="sidebar_not_logged_message">¡Bienvenido a Raccoon!\n\nEn modo anónimo, usa el botón desplegable (▼) de arriba para cambiar de instancia.\n\nPuedes iniciar sesión en tu instancia en cualquier momento desde la pestaña Perfil.\n\n¡Disfruta de Lemmy!</string>
     <string name="undetermined">Indefinido</string>
     <string name="user_detail_info">Información sobre el usuario</string>
     <string name="user_info_admin">Administrador</string>

--- a/shared/src/commonMain/composeResources/values-ga/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ga/strings.xml
@@ -139,8 +139,8 @@
     <string name="home_sort_type_top_year_short">bliain</string>
     <string name="inbox_chat_message">Teachtaireacht</string>
     <string name="inbox_item_mention">a luadh tú i</string>
-    <string name="inbox_item_reply_comment">d\'fhreagair sé do bharúil i</string>
-    <string name="inbox_item_reply_post">d\'fhreagair sé do phostáil i</string>
+    <string name="inbox_item_reply_comment">d'fhreagair sé do bharúil i</string>
+    <string name="inbox_item_reply_post">d'fhreagair sé do phostáil i</string>
     <string name="inbox_listing_type_all">Gach</string>
     <string name="inbox_listing_type_title">Cineál an bhosca isteach</string>
     <string name="inbox_listing_type_unread">Gan Léamh</string>

--- a/shared/src/commonMain/composeResources/values-pl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pl/strings.xml
@@ -424,7 +424,7 @@
     <string name="settings_zombie_mode_scroll_amount">Ilość przewijania trybu zombie</string>
     <string name="share_mode_file">Udostępnij jako plik</string>
     <string name="share_mode_url">Udostępnij jako adres URL</string>
-    <string name="sidebar_not_logged_message">Witamy w Raccoon dla Lemmy\'ego!\n\nW trybie anonimowym użyj przycisku rozwijanego (▼) powyżej, aby zmienić instancję.\n\nMożesz zalogować się do swojej instancji pod adresem w dowolnym momencie na ekranie profilu.\n\nCiesz się Lemmym!</string>
+    <string name="sidebar_not_logged_message">Witamy w Raccoon dla Lemmy'ego!\n\nW trybie anonimowym użyj przycisku rozwijanego (▼) powyżej, aby zmienić instancję.\n\nMożesz zalogować się do swojej instancji pod adresem w dowolnym momencie na ekranie profilu.\n\nCiesz się Lemmym!</string>
     <string name="undetermined">Nieokreślony</string>
     <string name="user_detail_info">Informacje o użytkowniku</string>
     <string name="user_info_admin">administrator</string>

--- a/shared/src/commonMain/composeResources/values-ua/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ua/strings.xml
@@ -29,7 +29,7 @@
     <string name="ban_item_duration_days">Тривалість (дні)</string>
     <string name="ban_item_permanent">Постійний бан</string>
     <string name="ban_item_remove_data">Видалити дані</string>
-    <string name="ban_reason_placeholder">Причина (необов\'язково)</string>
+    <string name="ban_reason_placeholder">Причина (необов'язково)</string>
     <string name="bar_theme_opaque">Непрозорий</string>
     <string name="bar_theme_transparent">Прозорий</string>
     <string name="beta">Бета</string>
@@ -84,7 +84,7 @@
     <string name="create_post_tab_preview">Перегляд</string>
     <string name="create_post_title">Нова посада</string>
     <string name="create_post_url">URL</string>
-    <string name="create_report_placeholder">Текст звіту (необов\'язково)</string>
+    <string name="create_report_placeholder">Текст звіту (необов'язково)</string>
     <string name="create_report_title_comment">Скарга</string>
     <string name="create_report_title_post">Поскаржитися на повідомлення</string>
     <string name="dialog_raw_content_text">Текст</string>
@@ -152,10 +152,10 @@
     <string name="instance_detail_communities">Спільноти</string>
     <string name="instance_detail_title">примірник:</string>
     <string name="login_field_instance_name">Назва екземпляра</string>
-    <string name="login_field_label_optional">(необов\'язковий)</string>
+    <string name="login_field_label_optional">(необов'язковий)</string>
     <string name="login_field_password">Пароль</string>
     <string name="login_field_token">Токен TOTP 2FA</string>
-    <string name="login_field_user_name">Ім\'я користувача або адреса електронної пошти</string>
+    <string name="login_field_user_name">Ім'я користувача або адреса електронної пошти</string>
     <string name="manage_accounts_button_add">Додати рахунок</string>
     <string name="manage_accounts_title">Керування обліковими записами</string>
     <string name="manage_subscriptions_header_multicommunities">Мультиспільноти</string>
@@ -216,7 +216,7 @@
     <string name="modlog_title">Журнал модерації</string>
     <string name="multi_community_editor_communities">Спільноти</string>
     <string name="multi_community_editor_icon">Значок</string>
-    <string name="multi_community_editor_name">Ім\'я</string>
+    <string name="multi_community_editor_name">Ім'я</string>
     <string name="multi_community_editor_title">Редактор для кількох спільнот</string>
     <string name="navigation_drawer_anonymous">Анонімний</string>
     <string name="navigation_drawer_title_bookmarks">Збережено</string>
@@ -409,7 +409,7 @@
     <string name="settings_web_banner">банер</string>
     <string name="settings_web_bio">біографія</string>
     <string name="settings_web_bot">Бот</string>
-    <string name="settings_web_display_name">Відображуване ім\'я</string>
+    <string name="settings_web_display_name">Відображуване ім'я</string>
     <string name="settings_web_email">Електронна пошта</string>
     <string name="settings_web_email_notifications">Надсилати сповіщення електронною поштою</string>
     <string name="settings_web_header_contents">Зміст</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -184,7 +184,7 @@
     <string name="message_confirm_exit">Tap 🔙 again to exit</string>
     <string name="message_content_deleted">You have deleted this content</string>
     <string name="message_content_removed">(this content has been removed)</string>
-    <string name="message_empty_comments">It\'s too silent here.\nWould you like to be the one who writes the first comment?</string>
+    <string name="message_empty_comments">It's too silent here.\nWould you like to be the one who writes the first comment?</string>
     <string name="message_empty_list">No items to display</string>
     <string name="message_error_loading_comments">An error has occurred loading comments.</string>
     <string name="message_generic_error">Generic error</string>


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes escaped apostrophes which in Compose resources are treated literally.

## Additional notes
<!-- Anything to declare for code review? -->
This may break in future imports from Weblate so I'll have to be careful.
