### PR TITLE
fix(di): add missing bindings for settings import and export use cases

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/di/PersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/di/PersistenceModule.kt
@@ -22,6 +22,10 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Instanc
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.MultiCommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.StopWordRepository
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.DefaultExportSettingsUseCase
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.DefaultImportSettingsUseCase
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.ExportSettingsUseCase
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.ImportSettingsUseCase
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -105,6 +109,21 @@ val persistenceModule =
             singleton {
                 DefaultStopWordRepository(
                     keyStore = instance(),
+                )
+            }
+        }
+        bind<ImportSettingsUseCase> {
+            singleton {
+                DefaultImportSettingsUseCase(
+                    settingsRepository = instance(),
+                    accountRepository = instance(),
+                )
+            }
+        }
+        bind<ExportSettingsUseCase> {
+            singleton {
+                DefaultExportSettingsUseCase(
+                    settingsRepository = instance(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a crash due to which it was not possible to instantiate settings import and export use cases, which led to a crash when opening the Advanced settings screen.

## Additional notes
<!-- Anything to declare for code review? -->
This was accidentally introduced in #181.
