### PR TITLE
feat: implement user tags • part 1

### DIFF
--- a/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
@@ -3,13 +3,13 @@ package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
 import app.cash.sqldelight.Query
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toLong
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.GetBy
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.SettingsQueries
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.SettingsModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.entities.AppDatabase
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.provider.DatabaseProvider
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.settings.GetBy
 import com.livefast.eattrash.raccoonforlemmy.core.preferences.store.TemporaryKeyStore
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import io.mockk.Called

--- a/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepositoryTest.kt
@@ -1,0 +1,230 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
+
+import app.cash.sqldelight.Query
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.GetAllBy
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UserTagEntity
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UserTagMemberEntity
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UsertagmembersQueries
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UsertagsQueries
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagMemberModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.entities.AppDatabase
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.provider.DatabaseProvider
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.usertagmembers.GetBy
+import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class DefaultUserTagRepositoryTest {
+    @get:Rule
+    val dispatcherTestRule = DispatcherTestRule()
+
+    private val tagQuery = mockk<Query<UserTagEntity>>()
+    private val tagQueries =
+        mockk<UsertagsQueries>(relaxUnitFun = true) {
+            every { getBy(any()) } returns tagQuery
+            every { getAllBy(any()) } returns tagQuery
+            every { create(any(), any()) } returns mockk(relaxUnitFun = true)
+            every { update(any(), any()) } returns mockk(relaxUnitFun = true)
+            every { delete(any()) } returns mockk(relaxUnitFun = true)
+        }
+    private val memberQuery = mockk<Query<UserTagMemberEntity>>()
+    private val memberGetByQuery = mockk<Query<GetBy>>()
+    private val memberGetAllByQuery = mockk<Query<GetAllBy>>()
+    private val memberQueries =
+        mockk<UsertagmembersQueries>(relaxUnitFun = true) {
+            every { create(any(), any()) } returns mockk(relaxUnitFun = true)
+            every { delete(any(), any()) } returns mockk(relaxUnitFun = true)
+            every { getMembers(any()) } returns memberQuery
+            every { getBy(any(), any()) } returns memberGetByQuery
+            every { getAllBy(any(), any()) } returns memberGetAllByQuery
+        }
+    private val provider =
+        mockk<DatabaseProvider> {
+            every { getDatabase() } returns
+                mockk<AppDatabase> {
+                    every { usertagsQueries } returns tagQueries
+                    every { usertagmembersQueries } returns memberQueries
+                }
+        }
+    private val sut = DefaultUserTagRepository(provider)
+
+    @Test
+    fun whenGetAll_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            val accountId = 1L
+            val tagId = 2L
+            val model = UserTagModel(id = tagId, name = "tag")
+            every { tagQuery.executeAsList() } returns
+                listOf(
+                    UserTagEntity(
+                        id = tagId,
+                        name = model.name,
+                        account_id = accountId,
+                    ),
+                )
+
+            val res = sut.getAll(accountId)
+
+            assertEquals(1, res.size)
+            assertEquals(model, res.first())
+            verify {
+                tagQueries.getAllBy(accountId)
+            }
+        }
+
+    @Test
+    fun whenGetMembers_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            val tagId = 1L
+            val model = UserTagMemberModel(userTagId = tagId, username = "user-name")
+            every { memberQuery.executeAsList() } returns
+                listOf(
+                    UserTagMemberEntity(
+                        id = 0L,
+                        username = model.username,
+                        user_tag_id = tagId,
+                    ),
+                )
+
+            val res = sut.getMembers(tagId)
+
+            assertEquals(1, res.size)
+            assertEquals(model, res.first())
+            verify {
+                memberQueries.getMembers(tagId)
+            }
+        }
+
+    @Test
+    fun whenGetTags_thenResultAndInteractionsAreAsExpected() =
+        runTest {
+            val accountId = 1L
+            val tagId = 2L
+            val model = UserTagModel(id = tagId, name = "tag")
+            val username = "user-name"
+            every { memberGetAllByQuery.executeAsList() } returns
+                listOf(
+                    GetAllBy(
+                        id = 0L,
+                        name = model.name,
+                        username = username,
+                        user_tag_id = tagId,
+                        account_id = accountId,
+                        id_ = tagId,
+                    ),
+                )
+
+            val res =
+                sut.getTags(
+                    username = username,
+                    accountId = accountId,
+                )
+
+            assertEquals(1, res.size)
+            assertEquals(model, res.first())
+            verify {
+                memberQueries.getAllBy(
+                    username = username,
+                    account_id = accountId,
+                )
+            }
+        }
+
+    @Test
+    fun whenCreate_thenInteractionsAreAsExpected() =
+        runTest {
+            val model = UserTagModel(name = "tag")
+            val accountId = 1L
+
+            sut.create(model = model, accountId = accountId)
+
+            verify {
+                tagQueries.create(name = model.name, account_id = accountId)
+            }
+        }
+
+    @Test
+    fun whenUpdate_thenInteractionsAreAsExpected() =
+        runTest {
+            val tagId = 1L
+            val newName = "new-tag"
+
+            sut.update(id = tagId, name = newName)
+
+            verify {
+                tagQueries.update(id = tagId, name = newName)
+            }
+        }
+
+    @Test
+    fun whenDelete_thenInteractionsAreAsExpected() =
+        runTest {
+            val tagId = 1L
+
+            sut.delete(id = tagId)
+
+            verify {
+                tagQueries.delete(id = tagId)
+            }
+        }
+
+    @Test
+    fun whenAddMember_thenInteractionsAreAsExpected() =
+        runTest {
+            val tagId = 1L
+            val username = "user-name"
+
+            sut.addMember(username = username, userTagId = tagId)
+
+            verify {
+                memberQueries.create(username = username, user_tag_id = tagId)
+            }
+        }
+
+    @Test
+    fun whenRemoveMember_thenInteractionsAreAsExpected() =
+        runTest {
+            val tagId = 1L
+            val username = "user-name"
+
+            sut.removeMember(username = username, userTagId = tagId)
+
+            verify {
+                memberQueries.delete(username = username, user_tag_id = tagId)
+            }
+        }
+
+    @Test
+    fun whenGetBelonging_thenInteractionsAreAsExpected() =
+        runTest {
+            val accountId = 1L
+            val tagId = 2L
+            val username = "user-name"
+            val model = UserTagModel(name = "tag", id = tagId)
+            every { memberGetAllByQuery.executeAsList() } returns
+                listOf(
+                    GetAllBy(
+                        id = 0L,
+                        name = model.name,
+                        username = username,
+                        user_tag_id = tagId,
+                        account_id = accountId,
+                        id_ = tagId,
+                    ),
+                )
+
+            val res = sut.getBelonging(username = username, accountId = accountId)
+
+            assertEquals(1, res.size)
+            assertEquals(model, res.first())
+            verify {
+                memberQueries.getAllBy(username = username, account_id = accountId)
+            }
+        }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagMemberModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagMemberModel.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.data
+
+data class UserTagMemberModel(
+    val username: String,
+    val userTagId: Long,
+)
+
+data class UserTagModel(
+    val id: Long? = null,
+    val name: String,
+)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/di/PersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/di/PersistenceModule.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Default
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DefaultMultiCommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DefaultSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DefaultStopWordRepository
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DefaultUserTagRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DomainBlocklistRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.DraftRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.FavoriteCommunityRepository
@@ -22,6 +23,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Instanc
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.MultiCommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.StopWordRepository
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserTagRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.DefaultExportSettingsUseCase
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.DefaultImportSettingsUseCase
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.usecase.ExportSettingsUseCase
@@ -109,6 +111,13 @@ val persistenceModule =
             singleton {
                 DefaultStopWordRepository(
                     keyStore = instance(),
+                )
+            }
+        }
+        bind<UserTagRepository> {
+            singleton {
+                DefaultUserTagRepository(
+                    provider = instance(),
                 )
             }
         }

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -3,12 +3,12 @@ package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toLong
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toVoteFormat
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.repository.ContentFontScales
-import com.livefast.eattrash.raccoonforlemmy.core.persistence.GetBy
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.SettingsModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.toActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.provider.DatabaseProvider
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.settings.GetBy
 import com.livefast.eattrash.raccoonforlemmy.core.preferences.store.TemporaryKeyStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepository.kt
@@ -1,0 +1,123 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
+
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UserTagEntity
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.UserTagMemberEntity
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagMemberModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.provider.DatabaseProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultUserTagRepository(
+    provider: DatabaseProvider,
+) : UserTagRepository {
+    private val db = provider.getDatabase()
+
+    override suspend fun getAll(accountId: Long): List<UserTagModel> =
+        withContext(Dispatchers.IO) {
+            db.usertagsQueries
+                .getAllBy(accountId)
+                .executeAsList()
+                .map { it.toModel() }
+        }
+
+    override suspend fun getMembers(tagId: Long): List<UserTagMemberModel> =
+        withContext(Dispatchers.IO) {
+            db.usertagmembersQueries
+                .getMembers(tagId)
+                .executeAsList()
+                .map { it.toModel() }
+        }
+
+    override suspend fun getTags(
+        username: String,
+        accountId: Long,
+    ): List<UserTagModel> =
+        withContext(Dispatchers.IO) {
+            db.usertagmembersQueries
+                .getAllBy(username, accountId)
+                .executeAsList()
+                .map { e ->
+                    UserTagModel(
+                        name = e.name,
+                        id = e.user_tag_id ?: 0,
+                    )
+                }
+        }
+
+    override suspend fun create(
+        model: UserTagModel,
+        accountId: Long,
+    ) = withContext(Dispatchers.IO) {
+        db.usertagsQueries.create(
+            name = model.name,
+            account_id = accountId,
+        )
+    }
+
+    override suspend fun update(
+        id: Long,
+        name: String,
+    ) = withContext(Dispatchers.IO) {
+        db.usertagsQueries.update(
+            id = id,
+            name = name,
+        )
+    }
+
+    override suspend fun delete(id: Long) =
+        withContext(Dispatchers.IO) {
+            db.usertagsQueries.delete(id)
+        }
+
+    override suspend fun addMember(
+        username: String,
+        userTagId: Long,
+    ) = withContext(Dispatchers.IO) {
+        db.usertagmembersQueries.create(
+            username = username,
+            user_tag_id = userTagId,
+        )
+    }
+
+    override suspend fun removeMember(
+        username: String,
+        userTagId: Long,
+    ) = withContext(Dispatchers.IO) {
+        db.usertagmembersQueries.delete(
+            username = username,
+            user_tag_id = userTagId,
+        )
+    }
+
+    override suspend fun getBelonging(
+        accountId: Long,
+        username: String,
+    ): List<UserTagModel> =
+        withContext(Dispatchers.IO) {
+            db.usertagmembersQueries
+                .getAllBy(
+                    username = username,
+                    account_id = accountId,
+                ).executeAsList()
+                .map { e ->
+                    UserTagModel(
+                        name = e.name,
+                        id = e.user_tag_id ?: 0,
+                    )
+                }
+        }
+}
+
+private fun UserTagEntity.toModel() =
+    UserTagModel(
+        id = id,
+        name = name,
+    )
+
+private fun UserTagMemberEntity.toModel() =
+    UserTagMemberModel(
+        username = username,
+        userTagId = user_tag_id ?: 0,
+    )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/UserTagRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/UserTagRepository.kt
@@ -1,0 +1,42 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
+
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagMemberModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
+
+interface UserTagRepository {
+    suspend fun getAll(accountId: Long): List<UserTagModel>
+
+    suspend fun getMembers(tagId: Long): List<UserTagMemberModel>
+
+    suspend fun getTags(
+        username: String,
+        accountId: Long,
+    ): List<UserTagModel>
+
+    suspend fun create(
+        model: UserTagModel,
+        accountId: Long,
+    )
+
+    suspend fun update(
+        id: Long,
+        name: String,
+    )
+
+    suspend fun delete(id: Long)
+
+    suspend fun addMember(
+        username: String,
+        userTagId: Long,
+    )
+
+    suspend fun removeMember(
+        username: String,
+        userTagId: Long,
+    )
+
+    suspend fun getBelonging(
+        accountId: Long,
+        username: String,
+    ): List<UserTagModel>
+}

--- a/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/usertagmembers.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/usertagmembers.sq
@@ -1,0 +1,36 @@
+CREATE TABLE UserTagMemberEntity(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL,
+    user_tag_id INTEGER,
+    FOREIGN KEY (user_tag_id) REFERENCES UserTagEntity(id) ON DELETE CASCADE,
+    UNIQUE(username, user_tag_id)
+);
+
+create:
+INSERT OR IGNORE INTO UserTagMemberEntity (
+    username,
+    user_tag_id
+) VALUES (
+    ?,
+    ?
+);
+
+delete:
+DELETE
+FROM UserTagMemberEntity
+WHERE username = ? AND user_tag_id = ?;
+
+getBy:
+SELECT *
+FROM UserTagMemberEntity m JOIN UserTagEntity t ON m.user_tag_id = t.id
+WHERE m.username = ? AND t.account_id = ?;
+
+getAllBy:
+SELECT *
+FROM UserTagMemberEntity m JOIN UserTagEntity t ON m.user_tag_id = t.id
+WHERE m.username = ? AND t.account_id = ?;
+
+getMembers:
+SELECT *
+FROM UserTagMemberEntity
+WHERE user_tag_id = ?;

--- a/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/usertags.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/usertags.sq
@@ -1,0 +1,36 @@
+CREATE TABLE UserTagEntity(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    account_id INTEGER,
+    FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
+    UNIQUE (account_id, name)
+);
+
+create:
+INSERT OR IGNORE INTO UserTagEntity (
+    name,
+    account_id
+) VALUES (
+    ?,
+    ?
+);
+
+getAllBy:
+SELECT *
+FROM UserTagEntity
+WHERE account_id = ?;
+
+getBy:
+SELECT *
+FROM UserTagEntity
+WHERE id = ?;
+
+update:
+UPDATE UserTagEntity
+SET name = ?
+WHERE id = ?;
+
+delete:
+DELETE
+FROM UserTagEntity
+WHERE id = ?;

--- a/core/persistence/src/commonMain/sqldelight/migrations/39.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/39.sqm
@@ -1,0 +1,15 @@
+CREATE TABLE UserTagEntity(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    account_id INTEGER,
+    FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
+    UNIQUE (account_id, name)
+);
+
+CREATE TABLE UserTagMemberEntity(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL,
+    user_tag_id INTEGER,
+    FOREIGN KEY (user_tag_id) REFERENCES UserTagEntity(id) ON DELETE CASCADE,
+    UNIQUE(username, user_tag_id)
+);


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR contains the persistence and domain layers needed to implement user tagging as tracked by #195.

## Additional notes
<!-- Anything to declare for code review? -->
Future PRs will contain the UI and the business logic needed to manage tags and membership.