### PR TITLE
feat: implement user tags • part 3

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
@@ -6,6 +6,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
@@ -23,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.LinkAnnotation
@@ -165,49 +169,73 @@ fun CommunityAndCreatorInfo(
                                     onDoubleClick = onDoubleClick ?: {},
                                     onLongClick = onLongClick ?: {},
                                 ),
-                        text = buildAnnotatedString {
-                            pushLink(
-                                LinkAnnotation.Clickable("click-community") {
-                                    onOpenCommunity?.invoke(community)
-                                },
-                            )
-                            append(communityName)
-                            pop()
-                            if (compact && creator != null) {
-                                append(" • ")
+                        text =
+                            buildAnnotatedString {
                                 pushLink(
-                                    LinkAnnotation.Clickable("click-user") {
-                                        onOpenCreator?.invoke(creator)
+                                    LinkAnnotation.Clickable("click-community") {
+                                        onOpenCommunity?.invoke(community)
                                     },
                                 )
-                                pushStyle(SpanStyle(color = ancillaryColor))
-                                append(creatorName)
+                                append(communityName)
                                 pop()
-                                pop()
-                            }
-                        },
+                                if (compact && creator != null) {
+                                    append(" • ")
+                                    pushLink(
+                                        LinkAnnotation.Clickable("click-user") {
+                                            onOpenCreator?.invoke(creator)
+                                        },
+                                    )
+                                    pushStyle(SpanStyle(color = ancillaryColor))
+                                    append(creatorName)
+                                    pop()
+                                    pop()
+                                }
+                            },
                         style = MaterialTheme.typography.bodySmall,
                         color = if (creator == null) ancillaryColor else fullColor,
                         maxLines = 1,
                     )
                 }
                 if (creator != null && !compact) {
-                    Text(
-                        modifier =
-                            Modifier
-                                .onClick(
-                                    indication = null,
-                                    onClick = {
-                                        onOpenCreator?.invoke(creator)
-                                    },
-                                    onDoubleClick = onDoubleClick ?: {},
-                                    onLongClick = onLongClick ?: {},
-                                ),
-                        text = creatorName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = ancillaryColor,
-                        maxLines = 1,
-                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            modifier =
+                                Modifier
+                                    .onClick(
+                                        indication = null,
+                                        onClick = {
+                                            onOpenCreator?.invoke(creator)
+                                        },
+                                        onDoubleClick = onDoubleClick ?: {},
+                                        onLongClick = onLongClick ?: {},
+                                    ),
+                            text = creatorName,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = ancillaryColor,
+                            maxLines = 1,
+                        )
+
+                        // user tags
+                        if (creator.tags.isNotEmpty()) {
+                            LazyRow(
+                                modifier = Modifier.widthIn(max = 150.dp),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                            ) {
+                                items(creator.tags) { tag ->
+                                    IndicatorChip(
+                                        text = tag.name,
+                                        color =
+                                            tag.color?.let { Color(it) }
+                                                ?: MaterialTheme.colorScheme.onBackground,
+                                        full = true,
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
             if (isOp) {

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/IndicatorChip.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/IndicatorChip.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -22,14 +23,22 @@ fun IndicatorChip(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.onBackground,
+    full: Boolean = false,
 ) {
+    val shape = RoundedCornerShape(CornerSize.m)
     Box(
         modifier =
             modifier
                 .border(
                     color = color,
                     width = Dp.Hairline,
-                    shape = RoundedCornerShape(CornerSize.m),
+                    shape = shape,
+                ).then(
+                    if (full) {
+                        Modifier.background(color, shape)
+                    } else {
+                        Modifier
+                    },
                 ).padding(
                     vertical = Spacing.xxxs,
                     horizontal = Spacing.xs,
@@ -42,7 +51,21 @@ fun IndicatorChip(
             fontSize = 8.sp,
             fontFamily = FontFamily.Default,
             fontWeight = FontWeight.SemiBold,
-            color = color,
+            color =
+                if (full) {
+                    getReadableColorFor(color)
+                } else {
+                    color
+                },
         )
     }
+}
+
+private fun getReadableColorFor(backgroundColor: Color): Color {
+    val r = backgroundColor.red
+    val g = backgroundColor.green
+    val b = backgroundColor.blue
+    // calculate the Y (luma) component of the YIQ color space
+    val y = ((r * 0.299) + (g * 0.587) + (b * 0.114))
+    return if (y >= 0.5) Color.Black else Color.White
 }

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/AssignUserTagBottomSheet.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/AssignUserTagBottomSheet.kt
@@ -1,6 +1,6 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.modals
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -10,8 +10,12 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -42,6 +46,7 @@ fun AssignUserTagBottomSheet(
     initiallyCheckedIds: List<Long> = emptyList(),
     onSelect: ((List<Long>) -> Unit)? = null,
     onDismiss: (() -> Unit)? = null,
+    onAddNewTag: (() -> Unit)? = null,
 ) {
     val selectedIds =
         remember {
@@ -61,17 +66,31 @@ fun AssignUserTagBottomSheet(
         Column(
             modifier = Modifier.padding(bottom = Spacing.xs),
         ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-                text = LocalStrings.current.manageUserTagsTitle,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
+            Box {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                    text = LocalStrings.current.manageUserTagsTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                if (onAddNewTag != null) {
+                    IconButton(
+                        modifier = Modifier.align(Alignment.CenterEnd),
+                        onClick = {
+                            onAddNewTag()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.AddCircle,
+                            contentDescription = LocalStrings.current.buttonAdd,
+                        )
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(Spacing.xs))
             LazyColumn(
                 modifier = Modifier.padding(top = Spacing.m).height(400.dp),
-                verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 items(tags) { tag ->

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditUserTagDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditUserTagDialog.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.unit.usertags.components
+package com.livefast.eattrash.raccoonforlemmy.core.commonui.modals
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -30,12 +30,11 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeReposito
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toTypography
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsColorRow
-import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomColorPickerDialog
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun EditUserTagDialog(
+fun EditUserTagDialog(
     title: String,
     value: String = "",
     color: Color = MaterialTheme.colorScheme.primary,

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagMemberModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagMemberModel.kt
@@ -4,9 +4,3 @@ data class UserTagMemberModel(
     val username: String,
     val userTagId: Long,
 )
-
-data class UserTagModel(
-    val id: Long? = null,
-    val name: String,
-    val color: Int? = null,
-)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/UserTagModel.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.data
+
+data class UserTagModel(
+    val id: Long? = null,
+    val name: String,
+    val color: Int? = null,
+)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultUserTagRepository.kt
@@ -50,6 +50,7 @@ internal class DefaultUserTagRepository(
                     UserTagModel(
                         name = e.name,
                         id = e.user_tag_id ?: 0,
+                        color = e.color?.toInt(),
                     )
                 }
         }
@@ -116,6 +117,7 @@ internal class DefaultUserTagRepository(
                     UserTagModel(
                         name = e.name,
                         id = e.user_tag_id ?: 0,
+                        color = e.color?.toInt(),
                     )
                 }
         }

--- a/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCaseTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Setting
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -32,6 +33,7 @@ class DefaultLogoutUseCaseTest {
         mockk<BottomNavItemsRepository>(relaxUnitFun = true) {
             coEvery { get(accountId = any()) } returns BottomNavItemsRepository.DEFAULT_ITEMS
         }
+    private val userTagHelper = mockk<UserTagHelper>(relaxUnitFun = true)
     private val sut =
         DefaultLogoutUseCase(
             identityRepository = identityRepository,
@@ -41,6 +43,7 @@ class DefaultLogoutUseCaseTest {
             communitySortRepository = communitySortRepository,
             bottomNavItemsRepository = bottomNavItemsRepository,
             lemmyValueCache = lemmyValueCache,
+            userTagHelper = userTagHelper,
         )
 
     @Test
@@ -70,6 +73,7 @@ class DefaultLogoutUseCaseTest {
                 identityRepository.clearToken()
                 accountRepository.setActive(accountId, false)
                 settingsRepository.changeCurrentSettings(anonymousSettings)
+                userTagHelper.clear()
             }
         }
 }

--- a/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Setting
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -37,6 +38,7 @@ class DefaultSwitchAccountUseCaseTest {
         mockk<BottomNavItemsRepository>(relaxUnitFun = true) {
             coEvery { get(accountId = any()) } returns BottomNavItemsRepository.DEFAULT_ITEMS
         }
+    private val userTagHelper = mockk<UserTagHelper>(relaxUnitFun = true)
     private val sut =
         DefaultSwitchAccountUseCase(
             identityRepository = identityRepository,
@@ -48,6 +50,7 @@ class DefaultSwitchAccountUseCaseTest {
             communityPreferredLanguageRepository = communityPreferredLanguageRepository,
             bottomNavItemsRepository = bottomNavItemsRepository,
             lemmyValueCache = lemmyValueCache,
+            userTagHelper = userTagHelper,
         )
 
     @Test
@@ -97,6 +100,7 @@ class DefaultSwitchAccountUseCaseTest {
                 identityRepository.storeToken("new-token")
                 identityRepository.refreshLoggedState()
                 serviceProvider.changeInstance("new-instance")
+                userTagHelper.clear()
             }
         }
 }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -150,6 +150,7 @@ val identityModule =
                     settingsRepository = instance(),
                     communitySortRepository = instance(),
                     bottomNavItemsRepository = instance(),
+                    userTagHelper = instance(),
                     lemmyValueCache = instance(),
                 )
             }
@@ -165,6 +166,7 @@ val identityModule =
                     communitySortRepository = instance(),
                     communityPreferredLanguageRepository = instance(),
                     bottomNavItemsRepository = instance(),
+                    userTagHelper = instance(),
                     lemmyValueCache = instance(),
                 )
             }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Communi
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 
 internal class DefaultLogoutUseCase(
     private val identityRepository: IdentityRepository,
@@ -18,6 +19,7 @@ internal class DefaultLogoutUseCase(
     private val communitySortRepository: CommunitySortRepository,
     private val bottomNavItemsRepository: BottomNavItemsRepository,
     private val lemmyValueCache: LemmyValueCache,
+    private val userTagHelper: UserTagHelper,
 ) : LogoutUseCase {
     override suspend operator fun invoke() {
         notificationCenter.send(NotificationCenterEvent.ResetExplore)
@@ -37,5 +39,7 @@ internal class DefaultLogoutUseCase(
 
         val bottomBarSections = bottomNavItemsRepository.get(null)
         settingsRepository.changeCurrentBottomBarSections(bottomBarSections.toInts())
+
+        userTagHelper.clear()
     }
 }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Communi
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 
 internal class DefaultSwitchAccountUseCase(
     private val identityRepository: IdentityRepository,
@@ -23,6 +24,7 @@ internal class DefaultSwitchAccountUseCase(
     private val communityPreferredLanguageRepository: CommunityPreferredLanguageRepository,
     private val bottomNavItemsRepository: BottomNavItemsRepository,
     private val lemmyValueCache: LemmyValueCache,
+    private val userTagHelper: UserTagHelper,
 ) : SwitchAccountUseCase {
     override suspend fun invoke(account: AccountModel) {
         val accountId = account.id ?: return
@@ -50,5 +52,7 @@ internal class DefaultSwitchAccountUseCase(
 
         val bottomBarSections = bottomNavItemsRepository.get(accountId)
         settingsRepository.changeCurrentBottomBarSections(bottomBarSections.toInts())
+
+        userTagHelper.clear()
     }
 }

--- a/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/TagModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/TagModel.kt
@@ -1,0 +1,6 @@
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data
+
+data class TagModel(
+    val name: String,
+    val color: Int? = null,
+)

--- a/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/UserModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/UserModel.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data
 
+import kotlin.jvm.Transient
+
 data class UserModel(
     val id: Long = 0,
     val instanceId: Long = 0,
@@ -15,6 +17,7 @@ data class UserModel(
     val banned: Boolean = false,
     val updateDate: String? = null,
     val bot: Boolean = false,
+    @Transient val tags: List<TagModel> = emptyList(),
 )
 
 fun List<UserModel>.containsId(value: Long?): Boolean = any { it.id == value }

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultCommentPaginationManagerTest.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
@@ -41,6 +42,10 @@ class DefaultCommentPaginationManagerTest {
             val slot = slot<KClass<NotificationCenterEvent>>()
             every { subscribe(capture(slot)) } answers { MutableSharedFlow() }
         }
+    private val userTagHelper =
+        mockk<UserTagHelper> {
+            coEvery { any<UserModel>().withTags() } answers { firstArg() }
+        }
 
     private val sut =
         DefaultCommentPaginationManager(
@@ -48,6 +53,7 @@ class DefaultCommentPaginationManagerTest {
             commentRepository = commentRepository,
             userRepository = userRepository,
             notificationCenter = notificationCenter,
+            userTagHelper = userTagHelper,
             dispatcher = dispatcherTestRule.dispatcher,
         )
 

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultExplorePaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultExplorePaginationManagerTest.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepo
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
@@ -64,6 +65,10 @@ class DefaultExplorePaginationManagerTest {
         mockk<StopWordRepository>(relaxUnitFun = true) {
             coEvery { get(accountId = any()) } returns emptyList()
         }
+    private val userTagHelper =
+        mockk<UserTagHelper> {
+            coEvery { any<UserModel>().withTags() } answers { firstArg() }
+        }
 
     private val sut =
         DefaultExplorePaginationManager(
@@ -75,6 +80,7 @@ class DefaultExplorePaginationManagerTest {
             userRepository = userRepository,
             domainBlocklistRepository = domainBlocklistRepository,
             stopWordRepository = stopWordRepository,
+            userTagHelper = userTagHelper,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
+++ b/domain/lemmy/pagination/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManagerTest.kt
@@ -14,6 +14,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
@@ -60,6 +61,10 @@ class DefaultPostPaginationManagerTest {
         mockk<StopWordRepository>(relaxUnitFun = true) {
             coEvery { get(accountId = any()) } returns emptyList()
         }
+    private val userTagHelper =
+        mockk<UserTagHelper> {
+            coEvery { any<UserModel>().withTags() } answers { firstArg() }
+        }
 
     private val sut =
         DefaultPostPaginationManager(
@@ -73,6 +78,7 @@ class DefaultPostPaginationManagerTest {
             dispatcher = dispatcherTestRule.dispatcher,
             domainBlocklistRepository = domainBlocklistRepository,
             stopWordRepository = stopWordRepository,
+            userTagHelper = userTagHelper,
         )
 
     @Test

--- a/domain/lemmy/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
+++ b/domain/lemmy/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/di/LemmyPaginationModule.kt
@@ -26,6 +26,7 @@ val lemmyPaginationModule =
                     identityRepository = instance(),
                     commentRepository = instance(),
                     userRepository = instance(),
+                    userTagHelper = instance(),
                     notificationCenter = instance(),
                 )
             }
@@ -49,6 +50,7 @@ val lemmyPaginationModule =
                     userRepository = instance(),
                     domainBlocklistRepository = instance(),
                     stopWordRepository = instance(),
+                    userTagHelper = instance(),
                 )
             }
         }
@@ -77,6 +79,7 @@ val lemmyPaginationModule =
                     multiCommunityPaginator = instance(),
                     domainBlocklistRepository = instance(),
                     stopWordRepository = instance(),
+                    userTagHelper = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/domain/lemmy/repository/build.gradle.kts
+++ b/domain/lemmy/repository/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
                 implementation(libs.ktorfit.lib)
 
                 implementation(projects.core.api)
+                implementation(projects.core.persistence)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.lemmy.data)

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserTagHelperTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserTagHelperTest.kt
@@ -1,0 +1,125 @@
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.AccountModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserTagRepository
+import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.livefast.eattrash.raccoonforlemmy.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.TagModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DefaultUserTagHelperTest {
+    @get:Rule
+    val dispatcherTestRule = DispatcherTestRule()
+
+    private val accountRepository = mockk<AccountRepository>()
+    private val userTagRepository = mockk<UserTagRepository>()
+    private val cache = mockk<LruCache<String, List<UserTagModel>>>(relaxUnitFun = true)
+    private val sut =
+        DefaultUserTagHelper(
+            accountRepository = accountRepository,
+            userTagRepository = userTagRepository,
+            cache = cache,
+        )
+
+    @Test
+    fun giveNoActiveAccountAndCacheMiss_whenGet_thenResultIsAsExpected() =
+        runTest {
+            coEvery { accountRepository.getActive() } returns null
+            coEvery { cache.get(any()) } returns null
+            val user = UserModel(id = 1L, name = "user", host = "host")
+
+            val res =
+                with(sut) {
+                    user.withTags()
+                }
+
+            assertEquals(user, res)
+            coVerify {
+                cache.get(user.readableHandle)
+                accountRepository.getActive()
+                userTagRepository wasNot Called
+            }
+        }
+
+    @Test
+    fun givenCacheMiss_whenGet_thenResultIsAsExpected() =
+        runTest {
+            val tagName = "test"
+            val accountId = 2L
+            coEvery { cache.get(any()) } returns null
+            coEvery {
+                userTagRepository.getTags(any(), any())
+            } returns listOf(UserTagModel(id = 1, name = tagName))
+            coEvery {
+                accountRepository.getActive()
+            } returns
+                AccountModel(
+                    id = accountId,
+                    username = "",
+                    instance = "",
+                    jwt = "",
+                    active = true,
+                )
+            val user = UserModel(id = 1L, name = "user", host = "host")
+
+            val res =
+                with(sut) {
+                    user.withTags()
+                }
+
+            assertNotNull(res)
+            assertEquals(1, res.tags.size)
+            assertEquals(TagModel(name = tagName, color = null), res.tags.first())
+
+            coVerify {
+                cache.get(user.readableHandle)
+                accountRepository.getActive()
+                userTagRepository.getTags(username = user.readableHandle, accountId = accountId)
+            }
+        }
+
+    @Test
+    fun givenCacheHit_whenGet_thenResultIsAsExpected() =
+        runTest {
+            val tagName = "test"
+            coEvery { cache.get(any()) } returns listOf(UserTagModel(id = 1, name = tagName))
+            val user = UserModel(id = 1L, name = "user", host = "host")
+
+            val res =
+                with(sut) {
+                    user.withTags()
+                }
+
+            assertNotNull(res)
+            assertEquals(1, res.tags.size)
+            assertEquals(TagModel(name = tagName, color = null), res.tags.first())
+
+            coVerify {
+                cache.get(user.readableHandle)
+                accountRepository wasNot Called
+                userTagRepository wasNot Called
+            }
+        }
+
+    @Test
+    fun whenClear_thenInteractionsAreAsExpected() =
+        runTest {
+            sut.clear()
+
+            coVerify {
+                cache.clear()
+            }
+        }
+}

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserTagHelper.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserTagHelper.kt
@@ -1,0 +1,44 @@
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.AccountRepository
+import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserTagRepository
+import com.livefast.eattrash.raccoonforlemmy.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.TagModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.readableHandle
+
+internal class DefaultUserTagHelper(
+    private val accountRepository: AccountRepository,
+    private val userTagRepository: UserTagRepository,
+    private val cache: LruCache<String, List<UserTagModel>> = LruCache(100),
+) : UserTagHelper {
+    override suspend fun UserModel?.withTags(): UserModel? =
+        this?.let { user ->
+            val handle = user.readableHandle
+            val cachedValues = cache.get(handle)
+            if (cachedValues != null) {
+                user.with(tags = cachedValues)
+            } else {
+                val accountId = accountRepository.getActive()?.id ?: return@let user
+                val tags = userTagRepository.getTags(username = handle, accountId = accountId)
+                cache.put(handle, tags)
+                user.with(tags = tags)
+            }
+        }
+
+    private fun UserModel.with(tags: List<UserTagModel>): UserModel =
+        copy(
+            tags =
+                tags.map {
+                    TagModel(
+                        name = it.name,
+                        color = it.color,
+                    )
+                },
+        )
+
+    override suspend fun clear() {
+        cache.clear()
+    }
+}

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/UserTagHelper.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/UserTagHelper.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
+
+interface UserTagHelper {
+    suspend fun UserModel?.withTags(): UserModel?
+
+    suspend fun clear()
+}

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/di/LemmyRepositoryModule.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/di/LemmyRepositoryModule.kt
@@ -21,6 +21,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultPost
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultPrivateMessageRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultSiteRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultUserRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultUserTagHelper
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsHiddenPostsUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsMediaListUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
@@ -34,6 +35,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostReposit
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PrivateMessageRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -162,6 +164,14 @@ val lemmyRepositoryModule =
                 DefaultUserRepository(
                     services = instance(tag = "default"),
                     customServices = instance(tag = "custom"),
+                )
+            }
+        }
+        bind<UserTagHelper> {
+            singleton {
+                DefaultUserTagHelper(
+                    accountRepository = instance(),
+                    userTagRepository = instance(),
                 )
             }
         }

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
@@ -71,6 +71,11 @@ interface UserDetailMviModel :
         data class UpdateTags(
             val ids: List<Long>,
         ) : Intent
+
+        data class AddUserTag(
+            val name: String,
+            val color: Int? = null,
+        ) : Intent
     }
 
     data class UiState(

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
@@ -91,6 +92,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di.getFabNest
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.AssignUserTagBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheetItem
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.EditUserTagDialog
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SortBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
@@ -138,8 +140,8 @@ class UserDetailScreen(
                     UserDetailMviModelParams(
                         userId = userId,
                         otherInstance = otherInstance,
+                    ),
             )
-        )
         val uiState by model.uiState.collectAsState()
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -171,7 +173,8 @@ class UserDetailScreen(
         var shareBottomSheetUrls by remember { mutableStateOf<List<String>?>(null) }
         var sortBottomSheetOpened by remember { mutableStateOf(false) }
         var copyPostBottomSheet by remember { mutableStateOf<PostModel?>(null) }
-        var manageTagsBottomSheetOpened by remember { mutableStateOf(false) }
+        var manageUserTagsBottomSheetOpened by remember { mutableStateOf(false) }
+        var addNewUserTagDialogOpen by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
             model.effects
@@ -291,7 +294,7 @@ class UserDetailScreen(
                                         this +=
                                             Option(
                                                 OptionId.ManageTags,
-                                                LocalStrings.current.userTagsTitle,
+                                                LocalStrings.current.manageUserTagsTitle,
                                             )
                                     }
                                 }
@@ -373,7 +376,7 @@ class UserDetailScreen(
                                                 }
 
                                                 OptionId.ManageTags -> {
-                                                    manageTagsBottomSheetOpened = true
+                                                    manageUserTagsBottomSheetOpened = true
                                                 }
 
                                                 else -> Unit
@@ -1291,16 +1294,37 @@ class UserDetailScreen(
             )
         }
 
-        if (manageTagsBottomSheetOpened) {
+        if (manageUserTagsBottomSheetOpened) {
             AssignUserTagBottomSheet(
                 tags = uiState.availableUserTags,
                 initiallyCheckedIds = uiState.currentUserTagIds,
                 onDismiss = {
-                    manageTagsBottomSheetOpened = false
+                    manageUserTagsBottomSheetOpened = false
                 },
                 onSelect = { ids ->
-                    manageTagsBottomSheetOpened = false
+                    manageUserTagsBottomSheetOpened = false
                     model.reduce(UserDetailMviModel.Intent.UpdateTags(ids))
+                },
+                onAddNewTag = {
+                    addNewUserTagDialogOpen = true
+                },
+            )
+        }
+
+        if (addNewUserTagDialogOpen) {
+            EditUserTagDialog(
+                title = LocalStrings.current.buttonAdd,
+                value = "",
+                onClose = { name, color ->
+                    addNewUserTagDialogOpen = false
+                    if (name != null) {
+                        model.reduce(
+                            UserDetailMviModel.Intent.AddUserTag(
+                                name = name,
+                                color = color?.toArgb(),
+                            ),
+                        )
+                    }
                 },
             )
         }

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/di/UserDetailModule.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/di/UserDetailModule.kt
@@ -32,6 +32,7 @@ val userDetailModule =
                     hapticFeedback = instance(),
                     settingsRepository = instance(),
                     userTagRepository = instance(),
+                    userTagHelper = instance(),
                     accountRepository = instance(),
                     notificationCenter = instance(),
                     imagePreloadManager = instance(),

--- a/unit/usertags/build.gradle.kts
+++ b/unit/usertags/build.gradle.kts
@@ -23,6 +23,8 @@ kotlin {
                 implementation(projects.core.navigation)
                 implementation(projects.core.persistence)
                 implementation(projects.core.utils)
+
+                implementation(projects.domain.lemmy.repository)
             }
         }
     }

--- a/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/di/UserTagsModule.kt
+++ b/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/di/UserTagsModule.kt
@@ -17,6 +17,7 @@ val userTagsModule =
                 UserTagsViewModel(
                     accountRepository = instance(),
                     userTagRepository = instance(),
+                    userTagHelper = instance(),
                 )
             }
         }

--- a/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/list/UserTagsScreen.kt
+++ b/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/list/UserTagsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
@@ -48,11 +49,11 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.Option
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.OptionId
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.UserTagItem
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.EditUserTagDialog
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
-import com.livefast.eattrash.raccoonforlemmy.unit.usertags.components.EditUserTagDialog
 import com.livefast.eattrash.raccoonforlemmy.unit.usertags.detail.UserTagDetailScreen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -217,6 +218,20 @@ class UserTagsScreen : Screen {
                                 }
                             },
                         )
+                    }
+                    if (uiState.tags.isEmpty() && !uiState.initial) {
+                        item {
+                            Text(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = Spacing.xs),
+                                textAlign = TextAlign.Center,
+                                text = LocalStrings.current.messageEmptyList,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
                     }
                     item {
                         Spacer(modifier = Modifier.height(Spacing.xxxl))

--- a/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/list/UserTagsViewModel.kt
+++ b/unit/usertags/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/usertags/list/UserTagsViewModel.kt
@@ -5,11 +5,13 @@ import com.livefast.eattrash.raccoonforlemmy.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.UserTagModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.AccountRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserTagRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
 import kotlinx.coroutines.launch
 
 internal class UserTagsViewModel(
     private val accountRepository: AccountRepository,
     private val userTagRepository: UserTagRepository,
+    private val userTagHelper: UserTagHelper,
 ) : DefaultMviModel<UserTagsMviModel.Intent, UserTagsMviModel.UiState, UserTagsMviModel.Effect>(
         initialState = UserTagsMviModel.UiState(),
     ),
@@ -55,6 +57,7 @@ internal class UserTagsViewModel(
             val accountId = accountRepository.getActive()?.id ?: return@launch
             val tag = UserTagModel(name = name, color = color)
             userTagRepository.create(tag, accountId)
+            userTagHelper.clear()
             refresh()
         }
     }
@@ -70,6 +73,7 @@ internal class UserTagsViewModel(
                 name = name,
                 color = color,
             )
+            userTagHelper.clear()
             refresh()
         }
     }
@@ -77,6 +81,7 @@ internal class UserTagsViewModel(
     private fun removeTag(id: Long) {
         screenModelScope.launch {
             userTagRepository.delete(id)
+            userTagHelper.clear()
             refresh()
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR completes the implementation of the user tagging feature as per #195:
- retrieve tags while loading timelines, communities or searching
- display tags in indicator chips.

## Additional notes
<!-- Anything to declare for code review? -->
The list of tags for each user (given the current active account, as tags are account-specific) is stored in a volatile cache to avoid reading from the local DB too often.

<details><summary>Related PRs</summary>

- #196 
- #197
</details>

<div align="center">
<img src="https://github.com/user-attachments/assets/06cc35f1-e700-41c4-8dcd-f7e333e266ef" width="310" />
</div>
