### PR TITLE
fix(di): fix misconfigured binding for ServiceProvider

### DIFF
--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -160,7 +160,7 @@ val identityModule =
                 DefaultSwitchAccountUseCase(
                     identityRepository = instance(),
                     accountRepository = instance(),
-                    serviceProvider = instance(),
+                    serviceProvider = instance("default"),
                     notificationCenter = instance(),
                     settingsRepository = instance(),
                     communitySortRepository = instance(),


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a misconfiguration in the binding for `ServiceProvider` to instantiate `DefaultSwitchAccountUseCase`, which led to an application crash when trying to switch accounts.

## Additional notes
<!-- Anything to declare for code review? -->
Again this was introduced by #181 which was done in a hurry to unblock the F-Droid release (which is still stuck BTW so there was no need to rush).
