### PR TITLE
fix: explore result type bottom sheet title

### DIFF
--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -826,7 +826,7 @@ class ExploreScreen(
                     SearchResultType.Urls,
                 )
             CustomModalBottomSheet(
-                title = LocalStrings.current.inboxListingTypeTitle,
+                title = LocalStrings.current.exploreResultTypeTitle,
                 items =
                     values.map { value ->
                         CustomModalBottomSheetItem(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes the title of the bottom sheet to select the search result type in the Explore section.
