### PR TITLE
fix: explore listing type bottom sheet title

### DIFF
--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -787,7 +787,7 @@ class ExploreScreen(
                     this += ListingType.Local
                 }
             CustomModalBottomSheet(
-                title = LocalStrings.current.inboxListingTypeTitle,
+                title = LocalStrings.current.homeListingTitle,
                 items =
                     values.map { value ->
                         CustomModalBottomSheetItem(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes the title of the bottom sheet used to select the listing type in the Explore section.

<details><summary>Related PRs</summary>

- #205 
</details>

Both were introduced in the bottom sheet migration done in #44, #45
