### PR TITLE
Fix window insets and bar color

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforlemmy.core.appearance.theme
 
 import android.app.Activity
 import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
@@ -18,11 +19,19 @@ internal class DefaultBarColorProvider : BarColorProvider {
         barTheme: UiBarTheme,
     ) {
         val view = LocalView.current
+        val isSystemInDarkTheme = isSystemInDarkTheme()
         LaunchedEffect(theme, barTheme) {
             (view.context as? Activity)?.window?.apply {
                 val baseColor =
                     when (theme) {
                         UiTheme.Light -> Color.White
+                        UiTheme.Black, UiTheme.Dark -> Color.Black
+                        UiTheme.Default ->
+                            if (isSystemInDarkTheme) {
+                                Color.Black
+                            } else {
+                                Color.White
+                            }
                         else -> Color.Black
                     }
                 val barColor =
@@ -31,15 +40,17 @@ internal class DefaultBarColorProvider : BarColorProvider {
                         UiBarTheme.Transparent -> baseColor.copy(alpha = 0.01f)
                         else -> baseColor
                     }.toArgb()
-                statusBarColor = barColor
-                navigationBarColor = barColor
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    statusBarColor = barColor
+                    navigationBarColor = barColor
+                }
 
                 if (barTheme != UiBarTheme.Solid) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        setDecorFitsSystemWindows(false)
-                    }
+                    WindowCompat.setDecorFitsSystemWindows(this, false)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        isStatusBarContrastEnforced = true
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                            isStatusBarContrastEnforced = true
+                        }
                         isNavigationBarContrastEnforced = true
                     }
                 }

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/TopAppBarWindowInsets.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/TopAppBarWindowInsets.kt
@@ -1,0 +1,30 @@
+package com.livefast.eattrash.raccoonforlemmy.core.appearance.theme
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopAppBarState.toWindowInsets(): WindowInsets {
+    val scope = rememberCoroutineScope()
+    val maxTopInsetPx = with(LocalDensity.current) { Dimensions.maxTopBarInset.toPx() }
+    var topInsetPx by remember { mutableStateOf(maxTopInsetPx) }
+    val topInset = with(LocalDensity.current) { topInsetPx.toDp() }
+    snapshotFlow { collapsedFraction }
+        .onEach {
+            topInsetPx = maxTopInsetPx * (1 - it)
+        }.launchIn(scope)
+    return WindowInsets(0.dp, topInset, 0.dp, 0.dp)
+}

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCardPlaceholder.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCardPlaceholder.kt
@@ -1,6 +1,5 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,7 +26,7 @@ fun CommentCardPlaceholder(
     hideAuthor: Boolean = false,
 ) {
     Column(
-        modifier = modifier.background(MaterialTheme.colorScheme.background),
+        modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {
         if (!hideAuthor) {
@@ -38,7 +36,8 @@ fun CommentCardPlaceholder(
             ) {
                 Box(
                     modifier =
-                        Modifier.size(IconSize.s)
+                        Modifier
+                            .size(IconSize.s)
                             .clip(CircleShape)
                             .shimmerEffect(),
                 )
@@ -48,14 +47,16 @@ fun CommentCardPlaceholder(
                 ) {
                     Box(
                         modifier =
-                            Modifier.height(IconSize.s)
+                            Modifier
+                                .height(IconSize.s)
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(CornerSize.m))
                                 .shimmerEffect(),
                     )
                     Box(
                         modifier =
-                            Modifier.height(IconSize.s)
+                            Modifier
+                                .height(IconSize.s)
                                 .fillMaxWidth(0.5f)
                                 .clip(RoundedCornerShape(CornerSize.m))
                                 .shimmerEffect(),

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardPlaceholder.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardPlaceholder.kt
@@ -34,7 +34,7 @@ fun PostCardPlaceholder(
     when (postLayout) {
         PostLayout.Compact -> {
             Column(
-                modifier = modifier.background(MaterialTheme.colorScheme.background),
+                modifier = modifier,
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
                 Row(
@@ -43,7 +43,8 @@ fun PostCardPlaceholder(
                 ) {
                     Box(
                         modifier =
-                            Modifier.size(IconSize.s)
+                            Modifier
+                                .size(IconSize.s)
                                 .clip(CircleShape)
                                 .shimmerEffect(),
                     )
@@ -53,7 +54,8 @@ fun PostCardPlaceholder(
                     ) {
                         Box(
                             modifier =
-                                Modifier.height(IconSize.s)
+                                Modifier
+                                    .height(IconSize.s)
                                     .fillMaxWidth()
                                     .clip(RoundedCornerShape(CornerSize.m))
                                     .shimmerEffect(),
@@ -100,8 +102,7 @@ fun PostCardPlaceholder(
                         .clip(RoundedCornerShape(CornerSize.l))
                         .background(
                             color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
-                        )
-                        .padding(Spacing.s),
+                        ).padding(Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
             ) {
                 Row(
@@ -121,14 +122,16 @@ fun PostCardPlaceholder(
                     ) {
                         Box(
                             modifier =
-                                Modifier.height(IconSize.s)
+                                Modifier
+                                    .height(IconSize.s)
                                     .fillMaxWidth()
                                     .clip(RoundedCornerShape(CornerSize.m))
                                     .shimmerEffect(),
                         )
                         Box(
                             modifier =
-                                Modifier.height(IconSize.s)
+                                Modifier
+                                    .height(IconSize.s)
                                     .fillMaxWidth(0.5f)
                                     .clip(RoundedCornerShape(CornerSize.m))
                                     .shimmerEffect(),
@@ -137,7 +140,8 @@ fun PostCardPlaceholder(
                 }
                 Box(
                     modifier =
-                        Modifier.height(IconSize.l)
+                        Modifier
+                            .height(IconSize.l)
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(CornerSize.m))
                             .shimmerEffect(),
@@ -163,7 +167,6 @@ fun PostCardPlaceholder(
 
         PostLayout.Full -> {
             Column(
-                modifier = Modifier.background(MaterialTheme.colorScheme.background),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
             ) {
                 Row(
@@ -183,14 +186,16 @@ fun PostCardPlaceholder(
                     ) {
                         Box(
                             modifier =
-                                Modifier.height(IconSize.s)
+                                Modifier
+                                    .height(IconSize.s)
                                     .fillMaxWidth()
                                     .clip(RoundedCornerShape(CornerSize.m))
                                     .shimmerEffect(),
                         )
                         Box(
                             modifier =
-                                Modifier.height(IconSize.s)
+                                Modifier
+                                    .height(IconSize.s)
                                     .fillMaxWidth(0.5f)
                                     .clip(RoundedCornerShape(CornerSize.m))
                                     .shimmerEffect(),

--- a/core/commonui/modals/build.gradle.kts
+++ b/core/commonui/modals/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
             dependencies {
                 implementation(libs.compose.colorpicker)
                 implementation(libs.voyager.navigator)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.commonui.components)

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -12,7 +12,6 @@ kotlin {
             implementation(libs.stately.common)
             implementation(libs.voyager.navigator)
             implementation(libs.voyager.tab)
-            implementation(libs.voyager.bottomsheet)
             implementation(libs.voyager.screenmodel)
             implementation(libs.voyager.kodein)
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)

--- a/feature/inbox/build.gradle.kts
+++ b/feature/inbox/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.feature.inbox.main
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -18,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -37,6 +38,7 @@ import cafe.adriel.voyager.navigator.tab.TabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheetItem
@@ -65,7 +67,8 @@ object InboxScreen : Tab {
     override fun Content() {
         val model: InboxMviModel = rememberScreenModel()
         val uiState by model.uiState.collectAsState()
-        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
         val drawerCoordinator = remember { getDrawerCoordinator() }
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val settingsRepository = remember { getSettingsRepository() }
@@ -90,12 +93,10 @@ object InboxScreen : Tab {
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xxs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     navigationIcon = {
                         IconButton(

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
                 implementation(libs.ktor.cio)
 
                 implementation(projects.core.appearance)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -39,9 +38,9 @@ import cafe.adriel.voyager.navigator.tab.LocalTabNavigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabNavigator
 import cafe.adriel.voyager.navigator.tab.TabOptions
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.ModeratorZoneAction
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.toIcon
@@ -56,7 +55,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoo
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.feature.profile.menu.ProfileSideMenuScreen
 import com.livefast.eattrash.raccoonforlemmy.feature.profile.notlogged.ProfileNotLoggedScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.drafts.DraftsScreen
@@ -76,7 +74,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 internal object ProfileMainScreen : Tab {
     override val options: TabOptions
@@ -172,22 +169,10 @@ internal object ProfileMainScreen : Tab {
         }
 
         Scaffold(
-            modifier = Modifier.padding(Spacing.xxs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset = maxTopInset * (1 - it)
-                    }.launchIn(scope)
-
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     navigationIcon = {
                         IconButton(

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -11,7 +11,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -41,10 +41,6 @@ interface AdvancedSettingsMviModel :
             val value: Boolean,
         ) : Intent
 
-        data class ChangeEdgeToEdge(
-            val value: Boolean,
-        ) : Intent
-
         data class ChangeInfiniteScrollDisabled(
             val value: Boolean,
         ) : Intent
@@ -109,7 +105,6 @@ interface AdvancedSettingsMviModel :
         val zombieModeScrollAmount: Float = 100f,
         val markAsReadWhileScrolling: Boolean = true,
         val searchPostTitleOnly: Boolean = false,
-        val edgeToEdge: Boolean = true,
         val infiniteScrollDisabled: Boolean = false,
         val systemBarTheme: UiBarTheme = UiBarTheme.Transparent,
         val imageSourceSupported: Boolean = true,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -196,17 +196,6 @@ class AdvancedSettingsScreen : Screen {
                         },
                     )
 
-                    // edge to edge
-                    SettingsSwitchRow(
-                        title = LocalStrings.current.settingsEdgeToEdge,
-                        value = uiState.edgeToEdge,
-                        onValueChanged = { value ->
-                            model.reduce(
-                                AdvancedSettingsMviModel.Intent.ChangeEdgeToEdge(value),
-                            )
-                        },
-                    )
-
                     // system bar theme
                     SettingsRow(
                         title = LocalStrings.current.settingsBarTheme,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforlemmy.feature.settings.advanced
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -47,6 +47,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toReadableName
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsHeader
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
@@ -128,14 +129,15 @@ class AdvancedSettingsScreen : Screen {
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
-                    .background(MaterialTheme.colorScheme.background)
                     .onGloballyPositioned {
                         screenWidth = it.size.toSize().width
                     },
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -146,7 +146,6 @@ class AdvancedSettingsViewModel(
                     zombieModeScrollAmount = settings.zombieModeScrollAmount,
                     markAsReadWhileScrolling = settings.markAsReadWhileScrolling,
                     searchPostTitleOnly = settings.searchPostTitleOnly,
-                    edgeToEdge = settings.edgeToEdge,
                     infiniteScrollDisabled = !settings.infiniteScrollEnabled,
                     systemBarTheme = settings.systemBarTheme.toUiBarTheme(),
                     imageSourceSupported = galleryHelper.supportsCustomPath,
@@ -191,7 +190,6 @@ class AdvancedSettingsViewModel(
             is AdvancedSettingsMviModel.Intent.ChangeSearchPostTitleOnly ->
                 changeSearchPostTitleOnly(intent.value)
 
-            is AdvancedSettingsMviModel.Intent.ChangeEdgeToEdge -> changeEdgeToEdge(intent.value)
             is AdvancedSettingsMviModel.Intent.ChangeInfiniteScrollDisabled ->
                 changeInfiniteScrollDisabled(intent.value)
 
@@ -330,14 +328,6 @@ class AdvancedSettingsViewModel(
                 settingsRepository.currentSettings.value.copy(defaultExploreResultType = value.toInt())
             saveSettings(settings)
             notificationCenter.send(NotificationCenterEvent.ResetExplore)
-        }
-    }
-
-    private fun changeEdgeToEdge(value: Boolean) {
-        screenModelScope.launch {
-            updateState { it.copy(edgeToEdge = value) }
-            val settings = settingsRepository.currentSettings.value.copy(edgeToEdge = value)
-            saveSettings(settings)
         }
     }
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -56,6 +57,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeReposito
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toTypography
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.MultiColorPreview
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsColorRow
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsMultiColorRow
@@ -128,9 +130,10 @@ class SettingsColorAndFontScreen : Screen {
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -3,9 +3,9 @@ package com.livefast.eattrash.raccoonforlemmy.feature.settings.main
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -44,6 +44,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsHeader
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsRow
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
@@ -109,9 +110,11 @@ class SettingsScreen : Screen {
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
+                    windowInsets = topAppBarState.toWindowInsets(),
                     navigationIcon = {
                         if (navigationCoordinator.canPop.value) {
                             IconButton(
@@ -154,8 +157,7 @@ class SettingsScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .nestedScroll(scrollBehavior.nestedScrollConnection),
+                        ).nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize().verticalScroll(scrollState),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,6 @@ sqldelight-native = { module = "app.cash.sqldelight:native-driver", version.ref 
 
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
-voyager-bottomsheet = { module = "cafe.adriel.voyager:voyager-bottom-sheet-navigator", version.ref = "voyager" }
 voyager-tab = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
 voyager-transition = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 voyager-kodein = { module = "cafe.adriel.voyager:voyager-kodein", version.ref = "voyager" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -18,7 +18,6 @@ kotlin {
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.transition)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.api)
                 implementation(projects.core.appearance)

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -4,14 +4,13 @@ import androidx.compose.animation.core.InfiniteRepeatableSpec
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -141,10 +140,7 @@ class AccountSettingsScreen : Screen {
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -216,8 +212,7 @@ class AccountSettingsScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {

--- a/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
+++ b/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
@@ -1,8 +1,8 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.acknowledgements.main
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
@@ -50,12 +51,10 @@ class AcknowledgementsScreen : Screen {
         val uriHandler = LocalUriHandler.current
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(

--- a/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
+++ b/unit/ban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/ban/BanUserScreen.kt
@@ -102,7 +102,7 @@ class BanUserScreen(
         }
 
         Scaffold(
-            modifier = Modifier.navigationBarsPadding(),
+            modifier = Modifier.navigationBarsPadding().safeImePadding(),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -123,11 +123,8 @@ class InboxChatScreen(
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .navigationBarsPadding(),
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            modifier = Modifier.navigationBarsPadding().safeImePadding(),
             topBar = {
                 TopAppBar(
                     title = {
@@ -176,9 +173,9 @@ class InboxChatScreen(
                 Column(
                     modifier =
                         Modifier
+                            .navigationBarsPadding()
                             .safeImePadding()
                             .fillMaxWidth()
-                            .navigationBarsPadding()
                             .padding(bottom = Spacing.s)
                             .background(MaterialTheme.colorScheme.background),
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -61,7 +60,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -83,8 +81,8 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenuItem
@@ -114,7 +112,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.keepscreenon.rememberKeepScreenOn
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -138,7 +135,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScr
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 class CommunityDetailScreen(
     private val communityId: Long,
@@ -269,29 +265,10 @@ class CommunityDetailScreen(
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset =
-                            (maxTopInset * (1 - it)).let { insetValue ->
-                                if (uiState.searching) {
-                                    insetValue.coerceAtLeast(statusBarInset.toFloat())
-                                } else {
-                                    insetValue
-                                }
-                            }
-                    }.launchIn(scope)
-
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.configurecontentview
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -77,10 +77,7 @@ class ConfigureContentViewScreen : Screen {
         var selectPostBodyMaxLinesBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
+++ b/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
@@ -1,14 +1,13 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.configurenavbar
 
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -97,10 +96,7 @@ class ConfigureNavBarScreen : Screen {
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -154,8 +150,7 @@ class ConfigureNavBarScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -1,11 +1,11 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.configureswipeactions
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -83,10 +83,7 @@ class ConfigureSwipeActionsScreen : Screen {
         var selectActionBottomSheet by remember { mutableStateOf<ActionConfig?>(null) }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -157,9 +158,9 @@ class CreateCommentScreen(
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
-                    .background(MaterialTheme.colorScheme.background)
                     .navigationBarsPadding()
                     .safeImePadding(),
             topBar = {

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -243,9 +244,9 @@ class CreatePostScreen(
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
-                    .background(MaterialTheme.colorScheme.background)
                     .navigationBarsPadding()
                     .safeImePadding(),
             topBar = {

--- a/unit/drafts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -1,14 +1,13 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.drafts
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -72,10 +71,7 @@ class DraftsScreen : Screen {
         var itemToDelete by remember { mutableStateOf<DraftModel?>(null) }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xxs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -105,8 +101,7 @@ class DraftsScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -4,10 +4,10 @@ import androidx.compose.animation.core.InfiniteRepeatableSpec
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -140,10 +140,7 @@ class EditCommunityScreen(
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/explore/build.gradle.kts
+++ b/unit/explore/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
                 implementation(libs.voyager.tab)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -191,6 +192,7 @@ class ExploreScreen(
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 ExploreTopBar(
                     topAppBarState = topAppBarState,
@@ -199,7 +201,6 @@ class ExploreScreen(
                     sortType = uiState.sortType,
                     resultType = uiState.resultType,
                     otherInstance = otherInstanceName,
-                    edgeToEdge = settings.edgeToEdge,
                     onSelectListingType = {
                         focusManager.clearFocus()
                         listingTypeBottomSheetOpened = true

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/components/ExploreTopBar.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.explore.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -17,32 +16,21 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SearchResultType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toReadableName
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,7 +39,6 @@ internal fun ExploreTopBar(
     listingType: ListingType,
     sortType: SortType,
     scrollBehavior: TopAppBarScrollBehavior? = null,
-    edgeToEdge: Boolean = true,
     resultType: SearchResultType,
     otherInstance: String = "",
     onSelectListingType: (() -> Unit)? = null,
@@ -60,21 +47,8 @@ internal fun ExploreTopBar(
     onHamburgerTapped: (() -> Unit)? = null,
     onBack: (() -> Unit)? = null,
 ) {
-    val scope = rememberCoroutineScope()
-    val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-    var topInset by remember { mutableStateOf(maxTopInset) }
-    snapshotFlow { topAppBarState.collapsedFraction }
-        .onEach {
-            topInset = maxTopInset * (1 - it)
-        }.launchIn(scope)
-
     TopAppBar(
-        windowInsets =
-            if (edgeToEdge) {
-                WindowInsets(0, topInset.roundToInt(), 0, 0)
-            } else {
-                TopAppBarDefaults.windowInsets
-            },
+        windowInsets = topAppBarState.toWindowInsets(),
         scrollBehavior = scrollBehavior,
         navigationIcon = {
             when {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.filteredcontents
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -47,7 +45,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -59,8 +56,8 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenuItem
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.SectionSelector
@@ -84,7 +81,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepo
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -101,7 +97,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScr
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 class FilteredContentsScreen(
     private val type: Int,
@@ -172,21 +167,10 @@ class FilteredContentsScreen(
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset = maxTopInset * (1 - it)
-                    }.launchIn(scope)
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     navigationIcon = {
                         if (navigationCoordinator.canPop.value) {
@@ -306,8 +290,7 @@ class FilteredContentsScreen(
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (connection != null && settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(connection)
                             } else {

--- a/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.instanceinfo
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -88,10 +88,7 @@ class InstanceInfoScreen(
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -1,8 +1,8 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.licences
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -47,10 +47,7 @@ class LicencesScreen : Screen {
         val uriHandler = LocalUriHandler.current
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/login/build.gradle.kts
+++ b/unit/login/build.gradle.kts
@@ -10,7 +10,6 @@ kotlin {
             dependencies {
                 implementation(libs.kodein)
                 implementation(libs.voyager.navigator)
-                implementation(libs.voyager.bottomsheet)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
 

--- a/unit/manageaccounts/build.gradle.kts
+++ b/unit/manageaccounts/build.gradle.kts
@@ -10,7 +10,6 @@ kotlin {
             dependencies {
                 implementation(libs.kodein)
                 implementation(libs.voyager.navigator)
-                implementation(libs.voyager.bottomsheet)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
 

--- a/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
+++ b/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
@@ -3,12 +3,11 @@ package com.livefast.eattrash.raccoonforlemmy.unit.manageban
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -126,7 +125,7 @@ class ManageBanScreen : Screen {
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -221,8 +220,7 @@ class ManageBanScreen : Screen {
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {

--- a/unit/medialist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/medialist/MediaListScreen.kt
+++ b/unit/medialist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/medialist/MediaListScreen.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.medialist
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -85,7 +85,7 @@ class MediaListScreen : Screen {
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     title = {

--- a/unit/moderatewithreason/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/moderatewithreason/ModerateWithReasonScreen.kt
+++ b/unit/moderatewithreason/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/moderatewithreason/ModerateWithReasonScreen.kt
@@ -98,7 +98,7 @@ class ModerateWithReasonScreen(
         }
 
         Scaffold(
-            modifier = Modifier.navigationBarsPadding(),
+            modifier = Modifier.navigationBarsPadding().safeImePadding(),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.modlog
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -92,10 +92,7 @@ class ModlogScreen(
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xxs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -58,8 +57,8 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenuItem
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.SwipeAction
@@ -81,7 +80,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
@@ -94,7 +92,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScr
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 class MultiCommunityScreen(
     private val communityId: Long,
@@ -145,21 +142,11 @@ class MultiCommunityScreen(
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 val sortType = uiState.sortType
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset = maxTopInset * (1 - it)
-                    }.launchIn(scope)
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     title = {
                         Text(
                             text = uiState.community.name,

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -66,7 +66,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -95,8 +94,8 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenuItem
@@ -124,7 +123,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -278,29 +276,10 @@ class PostDetailScreen(
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset =
-                            (maxTopInset * (1 - it)).let { insetValue ->
-                                if (uiState.searching) {
-                                    insetValue.coerceAtLeast(statusBarInset.toFloat())
-                                } else {
-                                    insetValue
-                                }
-                            }
-                    }.launchIn(scope)
-
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -201,7 +200,7 @@ class PostListScreen : Screen {
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 PostsTopBar(
                     currentInstance = uiState.instance,
@@ -209,7 +208,6 @@ class PostListScreen : Screen {
                     sortType = uiState.sortType,
                     scrollBehavior = scrollBehavior,
                     topAppBarState = topAppBarState,
-                    edgeToEdge = settings.edgeToEdge,
                     onHamburgerTapped = {
                         scope.launch {
                             drawerCoordinator.toggleDrawer()

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/components/PostsTopBar.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/components/PostsTopBar.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -18,32 +17,21 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toIcon
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toReadableName
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,27 +41,13 @@ internal fun PostsTopBar(
     listingType: ListingType?,
     sortType: SortType?,
     scrollBehavior: TopAppBarScrollBehavior? = null,
-    edgeToEdge: Boolean = true,
     onSelectListingType: (() -> Unit)? = null,
     onSelectInstance: (() -> Unit)? = null,
     onSelectSortType: (() -> Unit)? = null,
     onHamburgerTapped: (() -> Unit)? = null,
 ) {
-    val scope = rememberCoroutineScope()
-    val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-    var topInset by remember { mutableStateOf(maxTopInset) }
-    snapshotFlow { topAppBarState.collapsedFraction }
-        .onEach {
-            topInset = maxTopInset * (1 - it)
-        }.launchIn(scope)
-
     TopAppBar(
-        windowInsets =
-            if (edgeToEdge) {
-                WindowInsets(0, topInset.roundToInt(), 0, 0)
-            } else {
-                TopAppBarDefaults.windowInsets
-            },
+        windowInsets = topAppBarState.toWindowInsets(),
         scrollBehavior = scrollBehavior,
         navigationIcon = {
             when {

--- a/unit/rawcontent/build.gradle.kts
+++ b/unit/rawcontent/build.gradle.kts
@@ -10,7 +10,6 @@ kotlin {
             dependencies {
                 implementation(libs.kodein)
                 implementation(libs.voyager.navigator)
-                implementation(libs.voyager.bottomsheet)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.l10n)

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -1,15 +1,14 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.reportlist
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -110,10 +109,7 @@ class ReportListScreen(
         }
 
         Scaffold(
-            modifier =
-                Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(Spacing.xxs),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -162,8 +158,7 @@ class ReportListScreen(
                     Modifier
                         .padding(
                             top = padding.calculateTopPadding(),
-                        ).navigationBarsPadding()
-                        .then(
+                        ).then(
                             if (settings.hideNavigationBarWhileScrolling) {
                                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
                             } else {

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -50,7 +49,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -70,8 +68,8 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
-import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.FloatingActionButtonMenuItem
@@ -103,7 +101,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepo
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
-import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalPixel
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
@@ -122,7 +119,6 @@ import com.livefast.eattrash.raccoonforlemmy.unit.zoomableimage.ZoomableImageScr
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 class UserDetailScreen(
     private val userId: Long,
@@ -211,23 +207,11 @@ class UserDetailScreen(
         }
 
         Scaffold(
-            modifier = Modifier.background(MaterialTheme.colorScheme.background),
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 val userName = uiState.user.readableName(uiState.preferNicknames)
-                val maxTopInset = Dimensions.maxTopBarInset.toLocalPixel()
-                var topInset by remember { mutableStateOf(maxTopInset) }
-                snapshotFlow { topAppBarState.collapsedFraction }
-                    .onEach {
-                        topInset = maxTopInset * (1 - it)
-                    }.launchIn(scope)
-
                 TopAppBar(
-                    windowInsets =
-                        if (settings.edgeToEdge) {
-                            WindowInsets(0, topInset.roundToInt(), 0, 0)
-                        } else {
-                            TopAppBarDefaults.windowInsets
-                        },
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
@@ -483,8 +467,7 @@ class UserDetailScreen(
                             } else {
                                 Modifier
                             },
-                        ).navigationBarsPadding()
-                        .nestedScroll(fabNestedScrollConnection),
+                        ).nestedScroll(fabNestedScrollConnection),
                 isRefreshing = uiState.refreshing,
                 onRefresh = {
                     model.reduce(UserDetailMviModel.Intent.Refresh)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes some issues with window insets and status bar/navigation bar colors.

## Additional notes
<!-- Anything to declare for code review? -->
- an extension to `TopAppBarState` has been added to factor out top inset calculation;
- unnecessary backgrounds were removed from `Scaffold`s;
- the `voyager-bottom-sheet-navigator` dependency was not needed any more so it has been removed.
