### PR TITLE
enhancement: improve accessibility • part 2

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommunityAndCreatorInfo.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -108,7 +109,7 @@ fun CommunityAndCreatorInfo(
                                         }
                                     },
                                     onDoubleClick = onDoubleClick ?: {},
-                                ),
+                                ).clearAndSetSemantics { },
                         url = communityIcon,
                         autoload = autoLoadImages,
                         quality = FilterQuality.Low,
@@ -116,6 +117,7 @@ fun CommunityAndCreatorInfo(
                     )
                 } else {
                     PlaceholderImage(
+                        modifier = Modifier.clearAndSetSemantics { },
                         onClick = {
                             if (community != null) {
                                 onOpenCommunity?.invoke(community)
@@ -140,7 +142,7 @@ fun CommunityAndCreatorInfo(
                                         }
                                     },
                                     onDoubleClick = onDoubleClick ?: {},
-                                ),
+                                ).clearAndSetSemantics { },
                         url = creatorAvatar,
                         quality = FilterQuality.Low,
                         autoload = autoLoadImages,
@@ -148,6 +150,7 @@ fun CommunityAndCreatorInfo(
                     )
                 } else {
                     PlaceholderImage(
+                        modifier = Modifier.clearAndSetSemantics { },
                         onClick = {
                             if (creator != null) {
                                 onOpenCreator?.invoke(creator)
@@ -169,7 +172,7 @@ fun CommunityAndCreatorInfo(
                                     indication = null,
                                     onDoubleClick = onDoubleClick ?: {},
                                     onLongClick = onLongClick ?: {},
-                                ),
+                                ).clearAndSetSemantics { },
                         text =
                             buildAnnotatedString {
                                 pushLink(
@@ -212,7 +215,7 @@ fun CommunityAndCreatorInfo(
                                         },
                                         onDoubleClick = onDoubleClick ?: {},
                                         onLongClick = onLongClick ?: {},
-                                    ),
+                                    ).clearAndSetSemantics { },
                             text = creatorName,
                             style = MaterialTheme.typography.bodySmall,
                             color = ancillaryColor,
@@ -303,6 +306,7 @@ fun CommunityAndCreatorInfo(
             }
             if (indicatorExpanded != null) {
                 IconButton(
+                    modifier = Modifier.clearAndSetSemantics { },
                     onClick = {
                         onToggleExpanded?.invoke()
                     },

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxReplySubtitle.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxReplySubtitle.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -71,6 +72,7 @@ fun InboxReplySubtitle(
     upVotes: Int = 0,
     downVotes: Int = 0,
     downVoteEnabled: Boolean = true,
+    optionsMenuOpen: Boolean = false,
     options: List<Option> = emptyList(),
     voteFormat: VoteFormat = VoteFormat.Aggregated,
     upVoted: Boolean = false,
@@ -80,15 +82,15 @@ fun InboxReplySubtitle(
     onUpVote: (() -> Unit)? = null,
     onDownVote: (() -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
+    onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
     onReply: (() -> Unit)? = null,
 ) {
-    val buttonModifier = Modifier.size(IconSize.l)
+    val buttonModifier = Modifier.size(IconSize.l).clearAndSetSemantics { }
     val themeRepository = remember { getThemeRepository() }
     val upVoteColor by themeRepository.upVoteColor.collectAsState()
     val downVoteColor by themeRepository.downVoteColor.collectAsState()
     val defaultUpvoteColor = MaterialTheme.colorScheme.primary
     val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
-    var optionsExpanded by remember { mutableStateOf(false) }
     var optionsOffset by remember { mutableStateOf(Offset.Zero) }
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha)
 
@@ -118,7 +120,7 @@ fun InboxReplySubtitle(
                                                 onOpenCreator?.invoke(creator)
                                             }
                                         },
-                                    ),
+                                    ).clearAndSetSemantics { },
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
                         ) {
@@ -156,7 +158,7 @@ fun InboxReplySubtitle(
                                                 onOpenCommunity?.invoke(community)
                                             }
                                         },
-                                    ),
+                                    ).clearAndSetSemantics { },
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                         ) {
@@ -237,7 +239,7 @@ fun InboxReplySubtitle(
                                             optionsOffset = it.positionInParent()
                                         },
                                 onClick = {
-                                    optionsExpanded = true
+                                    onOptionsMenuToggled?.invoke(true)
                                 },
                             ) {
                                 Icon(
@@ -310,9 +312,9 @@ fun InboxReplySubtitle(
                         }
                     }
                     CustomDropDown(
-                        expanded = optionsExpanded,
+                        expanded = optionsMenuOpen,
                         onDismiss = {
-                            optionsExpanded = false
+                            onOptionsMenuToggled?.invoke(false)
                         },
                         offset =
                             DpOffset(
@@ -326,7 +328,7 @@ fun InboxReplySubtitle(
                                     Text(option.text)
                                 },
                                 onClick = {
-                                    optionsExpanded = false
+                                    onOptionsMenuToggled?.invoke(false)
                                     onOptionSelected?.invoke(option.id)
                                 },
                             )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardFooter.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.VoteFormat
@@ -71,12 +72,14 @@ fun PostCardFooter(
     actionButtonsActive: Boolean = true,
     markRead: Boolean = false,
     downVoteEnabled: Boolean = true,
+    optionsMenuOpen: Boolean = false,
     options: List<Option> = emptyList(),
     onClick: (() -> Unit)? = null,
     onUpVote: (() -> Unit)? = null,
     onDownVote: (() -> Unit)? = null,
     onSave: (() -> Unit)? = null,
     onReply: (() -> Unit)? = null,
+    onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
 ) {
     var optionsOffset by remember { mutableStateOf(Offset.Zero) }
@@ -88,7 +91,6 @@ fun PostCardFooter(
     val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
     val ancillaryColor =
         MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha * additionalAlphaFactor)
-    var optionsMenuOpen by remember { mutableStateOf(false) }
 
     CustomizedContent(ContentFontClass.AncillaryText) {
         Box(
@@ -100,7 +102,7 @@ fun PostCardFooter(
                     },
                     onLongClick = {
                         if (!optionsMenuOpen) {
-                            optionsMenuOpen = true
+                            onOptionsMenuToggled?.invoke(true)
                         }
                     },
                 ),
@@ -109,7 +111,7 @@ fun PostCardFooter(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
             ) {
-                val buttonModifier = Modifier.size(IconSize.l)
+                val buttonModifier = Modifier.size(IconSize.l).clearAndSetSemantics { }
                 if (comments != null) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
@@ -200,9 +202,9 @@ fun PostCardFooter(
                                 .padding(Spacing.xs)
                                 .onGloballyPositioned {
                                     optionsOffset = it.positionInParent()
-                                },
+                                }.clearAndSetSemantics { },
                         onClick = {
-                            optionsMenuOpen = true
+                            onOptionsMenuToggled?.invoke(true)
                         },
                     ) {
                         Icon(
@@ -303,7 +305,7 @@ fun PostCardFooter(
             CustomDropDown(
                 expanded = optionsMenuOpen,
                 onDismiss = {
-                    optionsMenuOpen = false
+                    onOptionsMenuToggled?.invoke(false)
                 },
                 offset =
                     DpOffset(
@@ -317,7 +319,7 @@ fun PostCardFooter(
                             Text(option.text)
                         },
                         onClick = {
-                            optionsMenuOpen = false
+                            onOptionsMenuToggled?.invoke(false)
                             onOptionSelected?.invoke(option.id)
                         },
                     )

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -60,8 +62,11 @@ fun PostCardTitle(
 
     SelectionContainer {
         CustomMarkdownWrapper(
-            modifier = modifier.padding(horizontal = Spacing.xxs),
-            content = text,
+            modifier =
+                modifier
+                    .padding(horizontal = Spacing.xxs)
+                    .semantics { heading() },
+                content = text,
             autoLoadImages = autoLoadImages,
             typography =
                 markdownTypography(

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsHeader.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsHeader.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 
@@ -43,6 +45,7 @@ fun SettingsHeader(
             )
         }
         Text(
+            modifier = Modifier.semantics { heading() },
             text = title,
             color = fullColor,
             style = MaterialTheme.typography.titleMedium,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
@@ -39,6 +39,7 @@ interface Strings {
     val actionOpenOptionMenu: String @Composable get
     val actionOpenSideMenu: String @Composable get
     val actionQuote: String @Composable get
+    val actionRemoveFromBookmarks: String @Composable get
     val actionReply: String @Composable get
     val actionRestore: String @Composable get
     val actionSave: String @Composable get

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_exit_search">Exit search</string>
     <string name="action_logout">Logout</string>
     <string name="action_quote">Quote</string>
+    <string name="action_remove_from_bookmarks">Remove from saved</string>
     <string name="action_reply">Reply</string>
     <string name="action_restore">Restore</string>
     <string name="action_save">Save</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
@@ -42,6 +42,7 @@ import raccoonforlemmy.shared.generated.resources.action_open_full_screen
 import raccoonforlemmy.shared.generated.resources.action_open_option_menu
 import raccoonforlemmy.shared.generated.resources.action_open_side_menu
 import raccoonforlemmy.shared.generated.resources.action_quote
+import raccoonforlemmy.shared.generated.resources.action_remove_from_bookmarks
 import raccoonforlemmy.shared.generated.resources.action_reply
 import raccoonforlemmy.shared.generated.resources.action_restore
 import raccoonforlemmy.shared.generated.resources.action_save
@@ -585,6 +586,8 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_open_side_menu)
     override val actionQuote: String
         @Composable get() = stringResource(Res.string.action_quote)
+    override val actionRemoveFromBookmarks: String
+        @Composable get() = stringResource(Res.string.action_remove_from_bookmarks)
     override val actionReply: String
         @Composable get() = stringResource(Res.string.action_reply)
     override val actionRestore: String

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgeCommentItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgeCommentItem.kt
@@ -29,7 +29,7 @@ internal fun AdminPurgeCommentItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.admin,
+        creator = item.admin,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgeCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgeCommunityItem.kt
@@ -25,7 +25,7 @@ internal fun AdminPurgeCommunityItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.admin,
+        creator = item.admin,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgePersonItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgePersonItem.kt
@@ -25,7 +25,7 @@ internal fun AdminPurgePersonItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.admin,
+        creator = item.admin,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgePostItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/AdminPurgePostItem.kt
@@ -25,7 +25,7 @@ internal fun AdminPurgePostItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.admin,
+        creator = item.admin,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/HideCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/HideCommunityItem.kt
@@ -29,7 +29,7 @@ internal fun HideCommunityItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.admin,
+        creator = item.admin,
         onOpenUser = onOpenUser,
         onOpen = {
             item.admin?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModAddCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModAddCommunityItem.kt
@@ -29,7 +29,7 @@ internal fun ModAddCommunityItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.user?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModAddItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModAddItem.kt
@@ -29,7 +29,7 @@ internal fun ModAddItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.user?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModBanFromCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModBanFromCommunityItem.kt
@@ -28,7 +28,7 @@ internal fun ModBanFromCommunityItem(
         autoLoadImages = autoLoadImages,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.user?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModBanItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModBanItem.kt
@@ -29,7 +29,7 @@ internal fun ModBanItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.user?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModFeaturePostItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModFeaturePostItem.kt
@@ -29,7 +29,7 @@ internal fun ModFeaturePostItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModLockPostItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModLockPostItem.kt
@@ -29,7 +29,7 @@ internal fun ModLockPostItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModRemoveCommentItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModRemoveCommentItem.kt
@@ -29,7 +29,7 @@ internal fun ModRemoveCommentItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModRemovePostItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModRemovePostItem.kt
@@ -29,7 +29,7 @@ internal fun ModRemovePostItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         innerContent = {
             Text(

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModTransferCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/ModTransferCommunityItem.kt
@@ -28,7 +28,7 @@ internal fun ModTransferCommunityItem(
         autoLoadImages = autoLoadImages,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.user?.also {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/RemoveCommunityItem.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/components/RemoveCommunityItem.kt
@@ -29,7 +29,7 @@ internal fun RemoveCommunityItem(
         preferNicknames = preferNicknames,
         date = item.date,
         postLayout = postLayout,
-        moderator = item.moderator,
+        creator = item.moderator,
         onOpenUser = onOpenUser,
         onOpen = {
             item.moderator?.also {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR continues the work on accessibility, merging complex elements with several nested actions into plain and more "digestible" items with all the actions set clearly in the root, to make it easier to reconstruct the structure of the page with a screen reader.

## Additional notes
<!-- Anything to declare for code review? -->
This is the counterpart of that I have been taught working on [rff#567](https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/567). Some rework was needed to be able to manage the options drop-down state from outside.

<details><summary>Related PRs</summary>

- #217 
</details>

These PRs are probably a 💧 in the 🌊 but somewhere I should start, shouldn't I?