### PR TITLE
fix: make settings switch row more accessible

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsSwitchRow.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsSwitchRow.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ancillaryTextAlpha
@@ -29,9 +30,14 @@ fun SettingsSwitchRow(
             Modifier
                 .clip(
                     shape = RoundedCornerShape(CornerSize.xxl),
-                ).clickable {
-                    onValueChanged(!value)
-                }.padding(horizontal = Spacing.m),
+                ).toggleable(
+                    value = value,
+                    role = Role.Checkbox,
+                    enabled = true,
+                    onValueChange = {
+                        onValueChanged(!value)
+                    },
+                ).padding(horizontal = Spacing.m),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -56,9 +62,7 @@ fun SettingsSwitchRow(
         Switch(
             modifier = Modifier.padding(start = Spacing.xs),
             checked = value,
-            onCheckedChange = {
-                onValueChanged(it)
-            },
+            onCheckedChange = null,
         )
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR makes `SettingsSwitchRow` more accessible by using the `toggleable` Modifier with its built-in semantics.

## Additional notes
<!-- Anything to declare for code review? -->
This is directly taken from Raccoon for Friendica 🦝
