### PR TITLE
enhancement: allow manual hex code selection in color picker for user tags

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsSwitchRow.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/SettingsSwitchRow.kt
@@ -60,7 +60,7 @@ fun SettingsSwitchRow(
             }
         }
         Switch(
-            modifier = Modifier.padding(start = Spacing.xs),
+            modifier = Modifier.padding(start = Spacing.xs, top = Spacing.xs),
             checked = value,
             onCheckedChange = null,
         )

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomColorPickerDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/CustomColorPickerDialog.kt
@@ -11,9 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
@@ -39,11 +44,13 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 @Composable
 fun CustomColorPickerDialog(
     initialValue: Color,
+    allowManualSelection: Boolean = false,
     onClose: ((Color?) -> Unit)? = null,
 ) {
     val controller = rememberColorPickerController()
     var selectedColor by remember { mutableStateOf(initialValue) }
     var selectedColorHex by remember { mutableStateOf("") }
+    var manualInputDialogOpen by remember { mutableStateOf(false) }
 
     BasicAlertDialog(
         modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
@@ -81,24 +88,42 @@ fun CustomColorPickerDialog(
                 },
             )
 
-            Box(
-                modifier =
-                    Modifier
-                        .border(
-                            color = selectedColor,
-                            width = 1.dp,
-                            shape = RoundedCornerShape(CornerSize.xxl),
-                        ).padding(
-                            horizontal = Spacing.m,
-                            vertical = Spacing.s,
-                        ),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = "#$selectedColorHex",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = selectedColor,
-                )
+                Box(
+                    modifier =
+                        Modifier
+                            .border(
+                                color = selectedColor,
+                                width = 1.dp,
+                                shape = RoundedCornerShape(CornerSize.xxl),
+                            ).padding(
+                                horizontal = Spacing.m,
+                                vertical = Spacing.s,
+                            ),
+                ) {
+                    SelectionContainer {
+                        Text(
+                            text = "#$selectedColorHex",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = selectedColor,
+                        )
+                    }
+                }
+                if (allowManualSelection) {
+                    FilledIconButton(
+                        onClick = {
+                            manualInputDialogOpen = true
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = LocalStrings.current.postActionEdit,
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(Spacing.s))
@@ -123,5 +148,53 @@ fun CustomColorPickerDialog(
                 }
             }
         }
+    }
+
+    if (manualInputDialogOpen) {
+        var isError by remember { mutableStateOf(false) }
+        var label by remember { mutableStateOf("") }
+        val invalidFieldMessage = LocalStrings.current.messageInvalidField
+
+        EditTextualInfoDialog(
+            title = LocalStrings.current.settingsColorDialogInsertHex,
+            value = selectedColorHex,
+            label = label,
+            isError = isError,
+            singleLine = true,
+            onClose = { value ->
+                val newColor = value?.toColor()
+                when {
+                    value != null && newColor == null -> {
+                        isError = true
+                        label = invalidFieldMessage
+                    }
+
+                    newColor != null -> {
+                        isError = false
+                        label = ""
+                        selectedColorHex = value
+                        selectedColor = newColor
+                        manualInputDialogOpen = false
+                    }
+
+                    else -> manualInputDialogOpen = false
+                }
+            },
+        )
+    }
+}
+
+private fun String.toColor(): Color? {
+    val sanitized =
+        if (startsWith("#")) {
+            substring(1)
+        } else {
+            this
+        }
+    return when {
+        sanitized.length == 6 || sanitized.length == 8 ->
+            sanitized.toLongOrNull(16)?.let { Color(it) }
+
+        else -> null
     }
 }

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditTextualInfoDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditTextualInfoDialog.kt
@@ -36,6 +36,8 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 fun EditTextualInfoDialog(
     title: String,
     label: String = "",
+    isError: Boolean = false,
+    singleLine: Boolean = false,
     value: String = "",
     onClose: ((String?) -> Unit)? = null,
 ) {
@@ -74,6 +76,8 @@ fun EditTextualInfoDialog(
                         unfocusedContainerColor = Color.Transparent,
                         disabledContainerColor = Color.Transparent,
                     ),
+                isError = isError,
+                singleLine = singleLine,
                 label = {
                     Text(
                         text = label,

--- a/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditUserTagDialog.kt
+++ b/core/commonui/modals/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/modals/EditUserTagDialog.kt
@@ -136,6 +136,7 @@ fun EditUserTagDialog(
     if (selectCustomColorDialogOpen) {
         CustomColorPickerDialog(
             initialValue = color,
+            allowManualSelection = true,
             onClose = { newColor ->
                 selectCustomColorDialogOpen = false
                 if (newColor != null) {

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
@@ -357,6 +357,7 @@ interface Strings {
     val settingsColorDialogAlpha: String @Composable get
     val settingsColorDialogBlue: String @Composable get
     val settingsColorDialogGreen: String @Composable get
+    val settingsColorDialogInsertHex: String @Composable get
     val settingsColorDialogRed: String @Composable get
     val settingsColorDialogTitle: String @Composable get
     val settingsColorGray: String @Composable get

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -324,6 +325,7 @@ class SettingsColorAndFontScreen : Screen {
         if (customColorBottomSheetOpened) {
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsCustomSeedColor,
+                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
                 items =
                     buildList {
                         this +=

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -310,6 +310,7 @@
     <string name="settings_color_dialog_alpha">A</string>
     <string name="settings_color_dialog_blue">B</string>
     <string name="settings_color_dialog_green">G</string>
+    <string name="settings_color_dialog_insert_hex">Insert hex color code</string>
     <string name="settings_color_dialog_red">R</string>
     <string name="settings_color_dialog_title">Pick a color</string>
     <string name="settings_color_gray">🦝 Ravenous raccoon</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
@@ -362,6 +362,7 @@ import raccoonforlemmy.shared.generated.resources.settings_color_custom
 import raccoonforlemmy.shared.generated.resources.settings_color_dialog_alpha
 import raccoonforlemmy.shared.generated.resources.settings_color_dialog_blue
 import raccoonforlemmy.shared.generated.resources.settings_color_dialog_green
+import raccoonforlemmy.shared.generated.resources.settings_color_dialog_insert_hex
 import raccoonforlemmy.shared.generated.resources.settings_color_dialog_red
 import raccoonforlemmy.shared.generated.resources.settings_color_dialog_title
 import raccoonforlemmy.shared.generated.resources.settings_color_gray
@@ -1229,6 +1230,8 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.settings_color_dialog_blue)
     override val settingsColorDialogGreen: String
         @Composable get() = stringResource(Res.string.settings_color_dialog_green)
+    override val settingsColorDialogInsertHex: String
+        @Composable get() = stringResource(Res.string.settings_color_dialog_insert_hex)
     override val settingsColorDialogRed: String
         @Composable get() = stringResource(Res.string.settings_color_dialog_red)
     override val settingsColorDialogTitle: String


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR allows to manually insert a color as hex code for user tag colors (with validation).

## Additional notes
<!-- Anything to declare for code review? -->
Other related small fixes:
- vertical padding in `SettingsSwitchRow`;
- make theme color selection bottom sheet skip partially expanded state.
