### PR TITLE
fix: include post read property in item keys

### DIFF
--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -276,7 +276,9 @@ class InboxChatScreen(
                         }
                         items(
                             items = uiState.messages,
-                            key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                            key = {
+                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                            },
                         ) { message ->
                             val isMyMessage = message.creator?.id == uiState.currentUserId
                             val content = message.content.orEmpty()

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -821,7 +821,9 @@ class CommunityDetailScreen(
                             }
                             items(
                                 items = uiState.posts,
-                                key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                                key = {
+                                    it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                },
                             ) { post ->
                                 LaunchedEffect(post.id) {
                                     if (settings.markAsReadWhileScrolling && !post.read) {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -369,7 +369,7 @@ class FilteredContentsScreen(
                         items(
                             items = uiState.posts,
                             key = {
-                                it.id.toString() + (it.updateDate ?: it.publishDate)
+                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
                             },
                         ) { post ->
 
@@ -708,8 +708,8 @@ class FilteredContentsScreen(
                             }
                         }
                         items(
-                            uiState.comments,
-                            { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                            items = uiState.comments,
+                            key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
                         ) { comment ->
 
                             @Composable

--- a/unit/messages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
+++ b/unit/messages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/messages/InboxMessagesScreen.kt
@@ -110,7 +110,9 @@ class InboxMessagesScreen : Tab {
                 items(
                     items = uiState.chats,
                     key = {
-                        it.id.toString() + (it.updateDate ?: it.publishDate) + it.read + uiState.unreadOnly
+                        it.id.toString() + (
+                            it.updateDate ?: it.publishDate
+                        ) + it.read + uiState.unreadOnly
                     },
                 ) { chat ->
                     ChatCard(

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -281,7 +281,9 @@ class MultiCommunityScreen(
                     }
                     items(
                         items = uiState.posts,
-                        key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                        key = {
+                            it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                        },
                     ) { post ->
                         LaunchedEffect(post.id) {
                             if (settings.markAsReadWhileScrolling && !post.read) {

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -276,7 +276,9 @@ object ProfileLoggedScreen : Tab {
                             }
                             items(
                                 items = uiState.posts,
-                                key = { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                                key = {
+                                    it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                },
                             ) { post ->
                                 PostCard(
                                     post = post,

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -360,9 +360,8 @@ class PostListScreen : Screen {
                             // isLogged is added to the key to force swipe action refresh
                             key = {
                                 it.id.toString() + (
-                                    it.updateDate
-                                        ?: it.publishDate
-                                ) + uiState.isLogged
+                                    it.updateDate ?: it.publishDate
+                                ) + it.read + uiState.isLogged
                             },
                         ) { post ->
                             LaunchedEffect(post.id) {

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -233,8 +233,7 @@ class ReportListScreen(
                                 items = uiState.postReports,
                                 key = {
                                     it.id.toString() + (
-                                        it.updateDate
-                                            ?: it.publishDate
+                                        it.updateDate ?: it.publishDate
                                     ) + it.resolved + uiState.unresolvedOnly
                                 },
                             ) { report ->
@@ -346,8 +345,12 @@ class ReportListScreen(
                                 }
                             }
                             items(
-                                uiState.commentReports,
-                                { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                                items = uiState.commentReports,
+                                key = {
+                                    it.id.toString() + (
+                                        it.updateDate ?: it.publishDate
+                                    ) + it.resolved
+                                },
                             ) { report ->
                                 SwipeActionCard(
                                     modifier = Modifier.fillMaxWidth(),

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -544,8 +544,10 @@ class UserDetailScreen(
                             }
                         }
                         items(
-                            uiState.posts,
-                            { it.id.toString() + (it.updateDate ?: it.publishDate) },
+                            items = uiState.posts,
+                            key = {
+                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                            },
                         ) { post ->
 
                             @Composable


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds the post `read` property to the compound key used to determine if an item needs recomposition in a lazy list. Its being not included could lead to posts not marked as read immediately when first entering the detail.

## Additional notes
<!-- Anything to declare for code review? -->
Apparently it was like this in the beginning (because I vaguely remember so, and because in inbox the `read` property was already included). Maybe some excessive optimization in the past brought its removal and, therefore, the bug.
