### PR TITLE
fix: set custom screen keys for side info panels

### DIFF
--- a/unit/communityinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
+++ b/unit/communityinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communityinfo/CommunityInfoScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.repository.ContentFontClass
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
@@ -57,6 +58,9 @@ class CommunityInfoScreen(
     private val communityName: String = "",
     private val otherInstance: String = "",
 ) : Screen {
+    override val key: ScreenKey
+        get() = super.key + communityId.toString()
+
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {

--- a/unit/userinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
+++ b/unit/userinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userinfo/UserInfoScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.repository.ContentFontClass
@@ -60,6 +61,9 @@ class UserInfoScreen(
     private val username: String,
     private val otherInstance: String,
 ) : Screen {
+    override val key: ScreenKey
+        get() = super.key + userId.toString()
+
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a bug due to which community info and user info did not update when they are opened again.
