### PR TITLE
feat: add possibility to delete account from web preferences

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -9,11 +9,12 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kodein)
-                implementation(libs.ktorfit.lib)
-                implementation(libs.ktor.serialization)
                 implementation(libs.ktor.contentnegotiation)
                 implementation(libs.ktor.json)
                 implementation(libs.ktor.logging)
+                implementation(libs.ktor.serialization)
+                implementation(libs.ktorfit.converters.response)
+                implementation(libs.ktorfit.lib)
 
                 implementation(projects.core.utils)
             }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/dto/DeleteAccountForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/dto/DeleteAccountForm.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforlemmy.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeleteAccountForm(
+    @SerialName("delete_content")
+    val deleteContent: Boolean,
+    @SerialName("password")
+    val password: String,
+    @SerialName("auth")
+    val auth: String,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/UserService.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.dto.BlockPersonForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.BlockPersonResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.CommentSortType
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.CommunityId
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.DeleteAccountForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.GetPersonDetailsResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.GetPersonMentionsResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.GetRepliesResponse
@@ -16,6 +17,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.dto.PurgePersonForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SaveUserSettingsForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SaveUserSettingsResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SuccessResponse
+import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Header
@@ -99,4 +101,11 @@ interface UserService {
         @Query("page") page: Int? = null,
         @Query("limit") limit: Int? = null,
     ): ListMediaResponse
+
+    @POST("user/delete_account")
+    @Headers("Content-Type: application/json")
+    suspend fun deleteAccount(
+        @Header("Authorization") authHeader: String? = null,
+        @Body form: DeleteAccountForm,
+    ): Response<Unit>
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/components/ProgressHud.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/components/ProgressHud.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun ProgressHud(
-    overlayColor: Color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.05f),
+    overlayColor: Color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f),
     color: Color = MaterialTheme.colorScheme.primary,
 ) {
     Box(

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
@@ -19,6 +19,7 @@ interface Strings {
     val actionCreatePost: String @Composable get
     val actionDeactivateZombieMode: String @Composable get
     val actionDecrement: String @Composable get
+    val actionDeleteAccount: String @Composable get
     val actionDownload: String @Composable get
     val actionDownvote: String @Composable get
     val actionExitSearch: String @Composable get
@@ -129,6 +130,8 @@ interface Strings {
     val defaultTagCurrentUser: String @Composable get
     val defaultTagModerator: String @Composable get
     val defaultTagOriginalPoster: String @Composable get
+    val deleteAccountBody: String @Composable get
+    val deleteAccountRemoveContent: String @Composable get
     val dialogRawContentText: String @Composable get
     val dialogRawContentTitle: String @Composable get
     val dialogRawContentUrl: String @Composable get

--- a/domain/lemmy/repository/build.gradle.kts
+++ b/domain/lemmy/repository/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
             dependencies {
                 implementation(libs.kodein)
                 implementation(libs.ktorfit.lib)
+                implementation(libs.ktorfit.converters.response)
 
                 implementation(projects.core.api)
                 implementation(projects.core.persistence)

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserRepositoryTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserRepositoryTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -710,6 +711,70 @@ class DefaultUserRepositoryTest {
                     pageCursor = null,
                     sort = SortType.New,
                     showHidden = true,
+                )
+            }
+        }
+
+    @Test
+    fun whenDeleteAccount_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                userService.deleteAccount(any(), any())
+            } returns
+                mockk(relaxUnitFun = true) {
+                    every { isSuccessful } returns true
+                }
+            val password = "fake-password"
+            val deleteContent = true
+
+            val res =
+                sut.deleteAccount(
+                    auth = AUTH_TOKEN,
+                    password = password,
+                    deleteContent = deleteContent,
+                )
+
+            assertTrue(res)
+            coVerify {
+                userService.deleteAccount(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    withArg {
+                        assertEquals(AUTH_TOKEN, it.auth)
+                        assertEquals(password, it.password)
+                        assertEquals(deleteContent, it.deleteContent)
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun givenError_whenDeleteAccount_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                userService.deleteAccount(any(), any())
+            } returns
+                mockk(relaxUnitFun = true) {
+                    every { isSuccessful } returns false
+                }
+            val password = "fake-password"
+            val deleteContent = true
+
+            val res =
+                sut.deleteAccount(
+                    auth = AUTH_TOKEN,
+                    password = password,
+                    deleteContent = deleteContent,
+                )
+
+            assertFalse(res)
+            coVerify {
+                userService.deleteAccount(
+                    authHeader = AUTH_TOKEN.toAuthHeader(),
+                    withArg {
+                        assertEquals(AUTH_TOKEN, it.auth)
+                        assertEquals(password, it.password)
+                        assertEquals(deleteContent, it.deleteContent)
+                    },
                 )
             }
         }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultUserRepository.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
 
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.BlockPersonForm
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.DeleteAccountForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.ListingType
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.MarkAllAsReadForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.MarkCommentAsReadForm
@@ -403,5 +404,27 @@ internal class DefaultUserRepository(
                 val posts = response.posts.map { it.toModel() }
                 posts to response.nextPage
             }.getOrNull()
+        }
+
+    override suspend fun deleteAccount(
+        auth: String?,
+        password: String,
+        deleteContent: Boolean,
+    ): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val data =
+                    DeleteAccountForm(
+                        auth = auth.orEmpty(),
+                        deleteContent = deleteContent,
+                        password = password,
+                    )
+                val res =
+                    services.user.deleteAccount(
+                        authHeader = auth.toAuthHeader(),
+                        form = data,
+                    )
+                res.isSuccessful
+            }.getOrElse { false }
         }
 }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/UserRepository.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/UserRepository.kt
@@ -127,4 +127,10 @@ interface UserRepository {
         limit: Int = PostRepository.DEFAULT_PAGE_SIZE,
         sort: SortType = SortType.New,
     ): Pair<List<PostModel>, String?>?
+
+    suspend fun deleteAccount(
+        auth: String?,
+        password: String,
+        deleteContent: Boolean = false,
+    ): Boolean
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit-ksp" }
 ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
+ktorfit-converters-response = { module = "de.jensklingenberg.ktorfit:ktorfit-converters-response", version.ref = "ktorfit" }
 
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="action_create_community">Create community</string>
     <string name="action_create_post">Create post</string>
     <string name="action_deactivate_zombie_mode">Deactivate zombie mode</string>
+    <string name="action_delete_account">Delete account</string>
     <string name="action_downvote">Downvote</string>
     <string name="action_exit_search">Exit search</string>
     <string name="action_logout">Logout</string>
@@ -94,6 +95,8 @@
     <string name="default_tag_current_user">me</string>
     <string name="default_tag_moderator">mod</string>
     <string name="default_tag_original_poster">op</string>
+    <string name="delete_account_body">Please enter your password to confirm account deletion.</string>
+    <string name="delete_account_remove_content">Delete content</string>
     <string name="dialog_raw_content_text">Text</string>
     <string name="dialog_raw_content_title">Title</string>
     <string name="dialog_raw_content_url">URL</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
@@ -22,6 +22,7 @@ import raccoonforlemmy.shared.generated.resources.action_create_community
 import raccoonforlemmy.shared.generated.resources.action_create_post
 import raccoonforlemmy.shared.generated.resources.action_deactivate_zombie_mode
 import raccoonforlemmy.shared.generated.resources.action_decrement
+import raccoonforlemmy.shared.generated.resources.action_delete_account
 import raccoonforlemmy.shared.generated.resources.action_download
 import raccoonforlemmy.shared.generated.resources.action_downvote
 import raccoonforlemmy.shared.generated.resources.action_exit_search
@@ -132,6 +133,8 @@ import raccoonforlemmy.shared.generated.resources.default_tag_bot
 import raccoonforlemmy.shared.generated.resources.default_tag_current_user
 import raccoonforlemmy.shared.generated.resources.default_tag_moderator
 import raccoonforlemmy.shared.generated.resources.default_tag_original_poster
+import raccoonforlemmy.shared.generated.resources.delete_account_body
+import raccoonforlemmy.shared.generated.resources.delete_account_remove_content
 import raccoonforlemmy.shared.generated.resources.dialog_raw_content_text
 import raccoonforlemmy.shared.generated.resources.dialog_raw_content_title
 import raccoonforlemmy.shared.generated.resources.dialog_raw_content_url
@@ -554,6 +557,8 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_deactivate_zombie_mode)
     override val actionDecrement: String
         @Composable get() = stringResource(Res.string.action_decrement)
+    override val actionDeleteAccount: String
+        @Composable get() = stringResource(Res.string.action_delete_account)
     override val actionDownload: String
         @Composable get() = stringResource(Res.string.action_download)
     override val actionDownvote: String
@@ -774,6 +779,10 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.default_tag_moderator)
     override val defaultTagOriginalPoster: String
         @Composable get() = stringResource(Res.string.default_tag_original_poster)
+    override val deleteAccountBody: String
+        @Composable get() = stringResource(Res.string.delete_account_body)
+    override val deleteAccountRemoveContent: String
+        @Composable get() = stringResource(Res.string.delete_account_remove_content)
     override val dialogRawContentText: String
         @Composable get() = stringResource(Res.string.dialog_raw_content_text)
     override val dialogRawContentTitle: String

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsMviModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsMviModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforlemmy.unit.accountsettings
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforlemmy.core.utils.ValidationError
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 
@@ -11,33 +12,61 @@ interface AccountSettingsMviModel :
     ScreenModel,
     MviModel<AccountSettingsMviModel.Intent, AccountSettingsMviModel.UiState, AccountSettingsMviModel.Effect> {
     sealed interface Intent {
-        data class ChangeDisplayName(val value: String) : Intent
+        data class ChangeDisplayName(
+            val value: String,
+        ) : Intent
 
-        data class ChangeEmail(val value: String) : Intent
+        data class ChangeEmail(
+            val value: String,
+        ) : Intent
 
-        data class ChangeMatrixUserId(val value: String) : Intent
+        data class ChangeMatrixUserId(
+            val value: String,
+        ) : Intent
 
-        data class ChangeBio(val value: String) : Intent
+        data class ChangeBio(
+            val value: String,
+        ) : Intent
 
-        data class ChangeBot(val value: Boolean) : Intent
+        data class ChangeBot(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeSendNotificationsToEmail(val value: Boolean) : Intent
+        data class ChangeSendNotificationsToEmail(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowBotAccounts(val value: Boolean) : Intent
+        data class ChangeShowBotAccounts(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowReadPosts(val value: Boolean) : Intent
+        data class ChangeShowReadPosts(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowNsfw(val value: Boolean) : Intent
+        data class ChangeShowNsfw(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowScores(val value: Boolean) : Intent
+        data class ChangeShowScores(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowUpVotes(val value: Boolean) : Intent
+        data class ChangeShowUpVotes(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowDownVotes(val value: Boolean) : Intent
+        data class ChangeShowDownVotes(
+            val value: Boolean,
+        ) : Intent
 
-        data class ChangeShowUpVotePercentage(val value: Boolean) : Intent
+        data class ChangeShowUpVotePercentage(
+            val value: Boolean,
+        ) : Intent
 
-        data class AvatarSelected(val value: ByteArray) : Intent {
+        data class AvatarSelected(
+            val value: ByteArray,
+        ) : Intent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other == null || this::class != other::class) return false
@@ -47,12 +76,12 @@ interface AccountSettingsMviModel :
                 return value.contentEquals(other.value)
             }
 
-            override fun hashCode(): Int {
-                return value.contentHashCode()
-            }
+            override fun hashCode(): Int = value.contentHashCode()
         }
 
-        data class BannerSelected(val value: ByteArray) : Intent {
+        data class BannerSelected(
+            val value: ByteArray,
+        ) : Intent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other == null || this::class != other::class) return false
@@ -62,16 +91,20 @@ interface AccountSettingsMviModel :
                 return value.contentEquals(other.value)
             }
 
-            override fun hashCode(): Int {
-                return value.contentHashCode()
-            }
+            override fun hashCode(): Int = value.contentHashCode()
         }
+
+        data class DeleteAccount(
+            val deleteContent: Boolean,
+            val password: String,
+        ) : Intent
 
         data object Submit : Intent
     }
 
     data class UiState(
         val loading: Boolean = false,
+        val operationInProgress: Boolean = false,
         val hasUnsavedChanges: Boolean = false,
         val avatar: String = "",
         val banner: String = "",
@@ -97,5 +130,13 @@ interface AccountSettingsMviModel :
         data object Success : Effect
 
         data object Failure : Effect
+
+        data class SetDeleteAccountValidationError(
+            val error: ValidationError?,
+        ) : Effect
+
+        data object CloseDeleteAccountDialog : Effect
+
+        data object Close : Effect
     }
 }

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
@@ -4,13 +4,16 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
+import com.livefast.eattrash.raccoonforlemmy.core.utils.ValidationError
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.AccountSettingsModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.MediaRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.launchIn
@@ -21,7 +24,9 @@ class AccountSettingsViewModel(
     private val siteRepository: SiteRepository,
     private val identityRepository: IdentityRepository,
     private val mediaRepository: MediaRepository,
+    private val userRepository: UserRepository,
     private val getSortTypesUseCase: GetSortTypesUseCase,
+    private val logoutUseCase: LogoutUseCase,
     private val notificationCenter: NotificationCenter,
 ) : DefaultMviModel<AccountSettingsMviModel.Intent, AccountSettingsMviModel.UiState, AccountSettingsMviModel.Effect>(
         initialState = AccountSettingsMviModel.UiState(),
@@ -56,7 +61,7 @@ class AccountSettingsViewModel(
 
     override fun reduce(intent: AccountSettingsMviModel.Intent) {
         when (intent) {
-            is AccountSettingsMviModel.Intent.ChangeDisplayName -> {
+            is AccountSettingsMviModel.Intent.ChangeDisplayName ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -65,9 +70,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeEmail -> {
+            is AccountSettingsMviModel.Intent.ChangeEmail ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -76,9 +80,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeMatrixUserId -> {
+            is AccountSettingsMviModel.Intent.ChangeMatrixUserId ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -87,9 +90,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeBio -> {
+            is AccountSettingsMviModel.Intent.ChangeBio ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -98,9 +100,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeBot -> {
+            is AccountSettingsMviModel.Intent.ChangeBot ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -109,9 +110,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeSendNotificationsToEmail -> {
+            is AccountSettingsMviModel.Intent.ChangeSendNotificationsToEmail ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -120,9 +120,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeShowBotAccounts -> {
+            is AccountSettingsMviModel.Intent.ChangeShowBotAccounts ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -131,9 +130,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeShowNsfw -> {
+            is AccountSettingsMviModel.Intent.ChangeShowNsfw ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -142,9 +140,8 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.ChangeShowScores -> {
+            is AccountSettingsMviModel.Intent.ChangeShowScores ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -153,7 +150,6 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
             is AccountSettingsMviModel.Intent.ChangeShowDownVotes ->
                 screenModelScope.launch {
@@ -185,7 +181,7 @@ class AccountSettingsViewModel(
                     }
                 }
 
-            is AccountSettingsMviModel.Intent.ChangeShowReadPosts -> {
+            is AccountSettingsMviModel.Intent.ChangeShowReadPosts ->
                 screenModelScope.launch {
                     updateState {
                         it.copy(
@@ -194,15 +190,16 @@ class AccountSettingsViewModel(
                         )
                     }
                 }
-            }
 
-            is AccountSettingsMviModel.Intent.AvatarSelected -> {
-                loadImageAvatar(intent.value)
-            }
+            is AccountSettingsMviModel.Intent.AvatarSelected -> loadImageAvatar(intent.value)
 
-            is AccountSettingsMviModel.Intent.BannerSelected -> {
-                loadImageBanner(intent.value)
-            }
+            is AccountSettingsMviModel.Intent.BannerSelected -> loadImageBanner(intent.value)
+
+            is AccountSettingsMviModel.Intent.DeleteAccount ->
+                deleteAccount(
+                    deleteContent = intent.deleteContent,
+                    password = intent.password,
+                )
 
             AccountSettingsMviModel.Intent.Submit -> submit()
         }
@@ -272,6 +269,51 @@ class AccountSettingsViewModel(
                         loading = false,
                     )
                 }
+            }
+        }
+    }
+
+    private fun deleteAccount(
+        deleteContent: Boolean,
+        password: String,
+    ) {
+        screenModelScope.launch {
+            if (password.isEmpty()) {
+                emitEffect(
+                    AccountSettingsMviModel.Effect.SetDeleteAccountValidationError(
+                        ValidationError.MissingField,
+                    ),
+                )
+                return@launch
+            }
+
+            if (uiState.value.operationInProgress) {
+                return@launch
+            }
+
+            emitEffect(AccountSettingsMviModel.Effect.SetDeleteAccountValidationError(null))
+            updateState { it.copy(operationInProgress = true) }
+
+            val auth = identityRepository.authToken.value
+            val success =
+                userRepository.deleteAccount(
+                    auth = auth,
+                    deleteContent = deleteContent,
+                    password = password,
+                )
+
+            if (success) {
+                emitEffect(AccountSettingsMviModel.Effect.CloseDeleteAccountDialog)
+                logoutUseCase()
+                updateState { it.copy(operationInProgress = false) }
+                emitEffect(AccountSettingsMviModel.Effect.Close)
+            } else {
+                updateState { it.copy(operationInProgress = false) }
+                emitEffect(
+                    AccountSettingsMviModel.Effect.SetDeleteAccountValidationError(
+                        ValidationError.InvalidField,
+                    ),
+                )
             }
         }
     }

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/components/DeleteAccountDialog.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/components/DeleteAccountDialog.kt
@@ -1,0 +1,173 @@
+package com.livefast.eattrash.raccoonforlemmy.unit.accountsettings.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforlemmy.core.commonui.lemmyui.SettingsSwitchRow
+import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
+import com.livefast.eattrash.raccoonforlemmy.core.utils.ValidationError
+import com.livefast.eattrash.raccoonforlemmy.core.utils.toReadableMessage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DeleteAccountDialog(
+    validationError: ValidationError? = null,
+    onDismiss: (() -> Unit)? = null,
+    onConfirm: ((String, Boolean) -> Unit)? = null,
+) {
+    var deleteContent by remember { mutableStateOf(false) }
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = ""))
+    }
+    var transformation: VisualTransformation by remember {
+        mutableStateOf(PasswordVisualTransformation())
+    }
+
+    BasicAlertDialog(
+        onDismissRequest = {
+            onDismiss?.invoke()
+        },
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .background(color = MaterialTheme.colorScheme.surface)
+                    .padding(Spacing.s),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = LocalStrings.current.actionDeleteAccount,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(Spacing.s))
+            Text(
+                text = LocalStrings.current.deleteAccountBody,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+
+            SettingsSwitchRow(
+                title = LocalStrings.current.deleteAccountRemoveContent,
+                value = deleteContent,
+                onValueChanged = {
+                    deleteContent = it
+                },
+            )
+            Spacer(modifier = Modifier.height(Spacing.xs))
+
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                    ),
+                isError = validationError != null,
+                singleLine = true,
+                label = {
+                    Text(
+                        text = LocalStrings.current.loginFieldPassword,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                supportingText = {
+                    if (validationError != null) {
+                        Text(
+                            text = validationError.toReadableMessage(),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                value = textFieldValue,
+                keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        autoCorrectEnabled = true,
+                    ),
+                onValueChange = { value ->
+                    textFieldValue = value
+                },
+                visualTransformation = transformation,
+                trailingIcon = {
+                    IconButton(
+                        onClick = {
+                            transformation =
+                                if (transformation == VisualTransformation.None) {
+                                    PasswordVisualTransformation()
+                                } else {
+                                    VisualTransformation.None
+                                }
+                        },
+                    ) {
+                        Icon(
+                            imageVector =
+                                if (transformation == VisualTransformation.None) {
+                                    Icons.Default.VisibilityOff
+                                } else {
+                                    Icons.Default.Visibility
+                                },
+                            contentDescription = LocalStrings.current.actionToggleVisibility,
+                        )
+                    }
+                },
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    onClick = {
+                        onDismiss?.invoke()
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonCancel)
+                }
+                Button(
+                    onClick = {
+                        onConfirm?.invoke(textFieldValue.text, deleteContent)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonConfirm)
+                }
+            }
+        }
+    }
+}

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/di/AccountSettingsModule.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/di/AccountSettingsModule.kt
@@ -15,7 +15,9 @@ val accountSettingsModule =
                     siteRepository = instance(),
                     identityRepository = instance(),
                     mediaRepository = instance(),
+                    userRepository = instance(),
                     getSortTypesUseCase = instance(),
+                    logoutUseCase = instance(),
                     notificationCenter = instance(),
                 )
             }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds the possibility to delete one's own account from the "Web preferences" screen.

## Additional notes
<!-- Anything to declare for code review? -->
The POST `user/delete_account` works differently from the documentation,[^1] so some adaptations, including installing a dedicated converter for network responses, were needed.

[^1]: Because it's Lemmy, folks, of course the software behaves differently from the specs!