### PR TITLE
fix(md): formatting quotes and bulleted lists inside quotes

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardBody.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
@@ -64,7 +63,7 @@ fun PostCardBody(
                         h6 = typography.titleSmall,
                         text = typography.bodyMedium,
                         paragraph = typography.bodyMedium,
-                        quote = typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+                        quote = typography.bodyMedium,
                         bullet = typography.bodyMedium,
                         list = typography.bodyMedium,
                         ordered = typography.bodyMedium,

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCardTitle.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeRepository
@@ -66,7 +65,7 @@ fun PostCardTitle(
                 modifier
                     .padding(horizontal = Spacing.xxs)
                     .semantics { heading() },
-                content = text,
+            content = text,
             autoLoadImages = autoLoadImages,
             typography =
                 markdownTypography(
@@ -78,7 +77,7 @@ fun PostCardTitle(
                     h6 = typography.titleSmall,
                     text = typography.bodyMedium.copy(fontWeight = weightMediumOrNormal),
                     paragraph = typography.bodyMedium.copy(fontWeight = weightMediumOrNormal),
-                    quote = typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+                    quote = typography.bodyMedium,
                     bullet = typography.bodyMedium,
                     list = typography.bodyMedium,
                     ordered = typography.bodyMedium,

--- a/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
@@ -72,17 +72,15 @@ private fun String.spoilerFixUp(): String =
 private fun String.quoteFixUp(): String =
     run {
         val finalLines = mutableListOf<String>()
-        val quoteAndList1 = Regex("^>-")
-        val quoteAndList2 = Regex("^> -")
-        val quoteEmpty = Regex("^>\\s*$")
         lines().forEach { originalLine ->
             val cleanLine =
                 originalLine
                     // removes list inside quotes
-                    .replace(quoteAndList1, "-")
-                    .replace(quoteAndList2, "> ")
-                    // replace empty quotes
-                    .replace(quoteEmpty, " \n")
+                    .replace(Regex("^>-"), "> •")
+                    .replace(Regex("^> -"), "> •")
+                    .replace(Regex("^> \\*"), "> •")
+                    // empty quotes
+                    .replace(Regex("^>\\s*$"), " \n")
             val isLastEmpty = finalLines.isNotEmpty() && finalLines.last().isEmpty()
             if (!isLastEmpty || cleanLine.isNotEmpty() || originalLine.isBlank()) {
                 finalLines += cleanLine


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a couple of bugs for markdown quotes:
- lists are sometimes skipped (plus, bullets were removed from an old fix)
- the Italic style was applies (because so it was in the original default typography) which can be confusing for users.

This solves both issues reported in #257.
