### PR TITLE
fix: remove bug in sanitization step which broke table rendering

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
@@ -81,13 +81,12 @@ private fun String.quoteFixUp(): String =
                     .replace(Regex("^> \\*"), "> •")
                     // empty quotes
                     .replace(Regex("^>\\s*$"), " \n")
-            val isLastEmpty = finalLines.isNotEmpty() && finalLines.last().isEmpty()
-            if (!isLastEmpty || cleanLine.isNotEmpty() || originalLine.isBlank()) {
+            if (cleanLine.isNotEmpty()) {
                 finalLines += cleanLine
+            }
+            if (originalLine.isBlank()) {
                 // blank lines to better isolate paragraphs
-                repeat(2) {
-                    finalLines += ""
-                }
+                finalLines += "\n\n"
             }
         }
         finalLines.joinToString("\n")


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a bug originated in a clumsy workaround for quotes (yes, always quotes) which accidentally prevented tables from being recognized and rendered correctly.

![image](https://github.com/user-attachments/assets/046a8329-1dfc-41f9-bed9-eeb19e7ce275)

