### PR TITLE
fix: avoid concurrency issue while posts are being marked as read before opening detail

### DIFF
--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -277,7 +277,7 @@ class InboxChatScreen(
                         items(
                             items = uiState.messages,
                             key = {
-                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                it.id.toString() + (it.updateDate ?: it.publishDate)
                             },
                         ) { message ->
                             val isMyMessage = message.creator?.id == uiState.currentUserId

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatViewModel.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatViewModel.kt
@@ -166,21 +166,19 @@ class InboxChatViewModel(
         }
     }
 
-    private fun markAsRead(
+    private suspend fun markAsRead(
         read: Boolean,
         messageId: Long,
     ) {
         val auth = identityRepository.authToken.value
-        screenModelScope.launch {
-            val newMessage =
-                messageRepository.markAsRead(
-                    read = read,
-                    messageId = messageId,
-                    auth = auth,
-                )
-            if (newMessage != null) {
-                handleMessageUpdate(newMessage)
-            }
+        val newMessage =
+            messageRepository.markAsRead(
+                read = read,
+                messageId = messageId,
+                auth = auth,
+            )
+        if (newMessage != null) {
+            handleMessageUpdate(newMessage)
         }
     }
 

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailMviModel.kt
@@ -102,7 +102,9 @@ interface CommunityDetailMviModel :
             val value: Boolean,
         ) : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val id: Long,
+        ) : Intent
 
         data object UnhideCommunity : Intent
 
@@ -175,5 +177,9 @@ interface CommunityDetailMviModel :
         ) : Effect
 
         data object Back : Effect
+
+        data class OpenDetail(
+            val post: PostModel,
+        ) : Effect
     }
 }

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -246,6 +246,8 @@ class CommunityDetailScreen(
                         }
 
                         CommunityDetailMviModel.Effect.Back -> navigationCoordinator.popScreen()
+                        is CommunityDetailMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(effect.post)
                     }
                 }.launchIn(this)
         }
@@ -822,7 +824,7 @@ class CommunityDetailScreen(
                             items(
                                 items = uiState.posts,
                                 key = {
-                                    it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                    it.id.toString() + (it.updateDate ?: it.publishDate)
                                 },
                             ) { post ->
                                 LaunchedEffect(post.id) {
@@ -977,11 +979,10 @@ class CommunityDetailScreen(
                                             meTagColor = uiState.meTagColor,
                                             onClick = {
                                                 model.reduce(
-                                                    CommunityDetailMviModel.Intent.MarkAsRead(
+                                                    CommunityDetailMviModel.Intent.WillOpenDetail(
                                                         post.id,
                                                     ),
                                                 )
-                                                model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
                                                 detailOpener.openPostDetail(
                                                     post = post,
                                                     otherInstance = otherInstanceName,
@@ -1027,11 +1028,10 @@ class CommunityDetailScreen(
                                             onReply =
                                                 {
                                                     model.reduce(
-                                                        CommunityDetailMviModel.Intent.MarkAsRead(
+                                                        CommunityDetailMviModel.Intent.WillOpenDetail(
                                                             post.id,
                                                         ),
                                                     )
-                                                    model.reduce(CommunityDetailMviModel.Intent.WillOpenDetail)
                                                     detailOpener.openPostDetail(post)
                                                 }.takeIf { uiState.isLogged && !isOnOtherInstance },
                                             onOpenImage = { url ->

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsMviModel.kt
@@ -100,7 +100,10 @@ interface FilteredContentsMviModel :
             val commentId: Long,
         ) : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Intent
     }
 
     data class State(
@@ -136,5 +139,10 @@ interface FilteredContentsMviModel :
 
     sealed interface Effect {
         data object BackToTop : Effect
+
+        data class OpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Effect
     }
 }

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -154,6 +154,13 @@ class FilteredContentsScreen(
                                 topAppBarState.contentOffset = 0f
                             }
                         }
+
+                        is FilteredContentsMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(
+                                post = PostModel(id = effect.postId),
+                                highlightCommentId = effect.commentId,
+                                isMod = true,
+                            )
                     }
                 }.launchIn(this)
         }
@@ -369,7 +376,7 @@ class FilteredContentsScreen(
                         items(
                             items = uiState.posts,
                             key = {
-                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                it.id.toString() + (it.updateDate ?: it.publishDate)
                             },
                         ) { post ->
 
@@ -482,8 +489,11 @@ class FilteredContentsScreen(
                                         botTagColor = uiState.botTagColor,
                                         meTagColor = uiState.meTagColor,
                                         onClick = {
-                                            model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(
+                                                FilteredContentsMviModel.Intent.WillOpenDetail(
+                                                    postId = post.id,
+                                                ),
+                                            )
                                         },
                                         onOpenCommunity = { community, instance ->
                                             detailOpener.openCommunityDetail(
@@ -512,8 +522,11 @@ class FilteredContentsScreen(
                                             )
                                         },
                                         onReply = {
-                                            model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(
+                                                FilteredContentsMviModel.Intent.WillOpenDetail(
+                                                    postId = post.id,
+                                                ),
+                                            )
                                         },
                                         onOpenImage = { url ->
                                             navigationCoordinator.pushScreen(
@@ -820,11 +833,11 @@ class FilteredContentsScreen(
                                             detailOpener.openUserDetail(user, instance)
                                         },
                                         onOpen = {
-                                            model.reduce(FilteredContentsMviModel.Intent.WillOpenDetail)
-                                            detailOpener.openPostDetail(
-                                                post = PostModel(id = comment.postId),
-                                                highlightCommentId = comment.id,
-                                                isMod = true,
+                                            model.reduce(
+                                                FilteredContentsMviModel.Intent.WillOpenDetail(
+                                                    postId = comment.postId,
+                                                    commentId = comment.id,
+                                                ),
                                             )
                                         },
                                         onUpVote = {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
@@ -212,10 +212,19 @@ class FilteredContentsViewModel(
                         distinguish(comment)
                     }
 
-            FilteredContentsMviModel.Intent.WillOpenDetail -> {
-                val state = postPaginationManager.extractState()
-                postNavigationManager.push(state)
-            }
+            is FilteredContentsMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    if (intent.commentId == null) {
+                        val state = postPaginationManager.extractState()
+                        postNavigationManager.push(state)
+                    }
+                    emitEffect(
+                        FilteredContentsMviModel.Effect.OpenDetail(
+                            postId = intent.postId,
+                            commentId = intent.commentId,
+                        ),
+                    )
+                }
         }
     }
 

--- a/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsMviModel.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsMviModel.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PersonMentionModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 
 @Stable
 interface InboxMentionsMviModel :
@@ -30,6 +31,12 @@ interface InboxMentionsMviModel :
 
         data class DownVoteComment(
             val id: Long,
+        ) : Intent
+
+        data class WillOpenDetail(
+            val id: Long,
+            val post: PostModel,
+            val commentId: Long,
         ) : Intent
     }
 
@@ -58,5 +65,10 @@ interface InboxMentionsMviModel :
         ) : Effect
 
         data object BackToTop : Effect
+
+        data class OpenDetail(
+            val post: PostModel,
+            val commentId: Long,
+        ) : Effect
     }
 }

--- a/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsScreen.kt
@@ -99,6 +99,12 @@ class InboxMentionsScreen : Tab {
                                 lazyListState.scrollToItem(0)
                             }
                         }
+
+                        is InboxMentionsMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(
+                                post = effect.post,
+                                highlightCommentId = effect.commentId,
+                            )
                     }
                 }.launchIn(this)
         }
@@ -138,7 +144,7 @@ class InboxMentionsScreen : Tab {
                 }
                 items(
                     items = uiState.mentions,
-                    key = { it.id.toString() + it.read + uiState.unreadOnly },
+                    key = { it.id.toString() + uiState.unreadOnly },
                 ) { mention ->
                     @Composable
                     fun List<ActionOnSwipe>.toSwipeActions(): List<SwipeAction> =
@@ -233,18 +239,12 @@ class InboxMentionsScreen : Tab {
                                 downVoteEnabled = uiState.downVoteEnabled,
                                 previewMaxLines = uiState.previewMaxLines,
                                 onClick = { post ->
-                                    if (!mention.read) {
-                                        model.reduce(
-                                            InboxMentionsMviModel.Intent.MarkAsRead(
-                                                read = true,
-                                                id = mention.id,
-                                            ),
-                                        )
-                                    }
-                                    detailOpener.openPostDetail(
-                                        post = post,
-                                        highlightCommentId = mention.comment.id,
-                                        otherInstance = "",
+                                    model.reduce(
+                                        InboxMentionsMviModel.Intent.WillOpenDetail(
+                                            id = mention.id,
+                                            post = post,
+                                            commentId = mention.comment.id,
+                                        ),
                                     )
                                 },
                                 onOpenCreator = { user, instance ->

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityMviModel.kt
@@ -48,7 +48,9 @@ interface MultiCommunityMviModel :
             val url: String,
         ) : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -83,5 +85,9 @@ interface MultiCommunityMviModel :
 
     sealed interface Effect {
         data object BackToTop : Effect
+
+        data class OpenDetail(
+            val post: PostModel,
+        ) : Effect
     }
 }

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -138,6 +138,9 @@ class MultiCommunityScreen(
                                 topAppBarState.contentOffset = 0f
                             }
                         }
+
+                        is MultiCommunityMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(post = effect.post)
                     }
                 }.launchIn(this)
         }
@@ -282,7 +285,7 @@ class MultiCommunityScreen(
                     items(
                         items = uiState.posts,
                         key = {
-                            it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                            it.id.toString() + (it.updateDate ?: it.publishDate)
                         },
                     ) { post ->
                         LaunchedEffect(post.id) {
@@ -404,9 +407,9 @@ class MultiCommunityScreen(
                                     botTagColor = uiState.botTagColor,
                                     meTagColor = uiState.meTagColor,
                                     onClick = {
-                                        model.reduce(MultiCommunityMviModel.Intent.MarkAsRead(post.id))
-                                        model.reduce(MultiCommunityMviModel.Intent.WillOpenDetail)
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(
+                                            MultiCommunityMviModel.Intent.WillOpenDetail(post.id),
+                                        )
                                     },
                                     onDoubleClick =
                                         {
@@ -439,8 +442,9 @@ class MultiCommunityScreen(
                                         )
                                     },
                                     onReply = {
-                                        model.reduce(MultiCommunityMviModel.Intent.WillOpenDetail)
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(
+                                            MultiCommunityMviModel.Intent.WillOpenDetail(post.id),
+                                        )
                                     },
                                     onOpenImage = { url ->
                                         model.reduce(MultiCommunityMviModel.Intent.MarkAsRead(post.id))

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedMviModel.kt
@@ -63,7 +63,10 @@ interface ProfileLoggedMviModel :
             val feedback: Boolean = false,
         ) : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Intent
 
         data class RestorePost(
             val id: Long,
@@ -96,5 +99,10 @@ interface ProfileLoggedMviModel :
         val isModerator: Boolean = false,
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data class OpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Effect
+    }
 }

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedScreen.kt
@@ -123,6 +123,18 @@ object ProfileLoggedScreen : Tab {
                     model.reduce(ProfileLoggedMviModel.Intent.Refresh)
                 }.launchIn(this)
         }
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { effect ->
+                    when (effect) {
+                        is ProfileLoggedMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(
+                                post = PostModel(id = effect.postId),
+                                highlightCommentId = effect.commentId,
+                            )
+                    }
+                }.launchIn(this)
+        }
 
         if (uiState.initial) {
             ProgressHud()
@@ -277,7 +289,7 @@ object ProfileLoggedScreen : Tab {
                             items(
                                 items = uiState.posts,
                                 key = {
-                                    it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                    it.id.toString() + (it.updateDate ?: it.publishDate)
                                 },
                             ) { post ->
                                 PostCard(
@@ -295,12 +307,18 @@ object ProfileLoggedScreen : Tab {
                                     blurNsfw = false,
                                     downVoteEnabled = uiState.downVoteEnabled,
                                     onClick = {
-                                        model.reduce(ProfileLoggedMviModel.Intent.WillOpenDetail)
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(
+                                            ProfileLoggedMviModel.Intent.WillOpenDetail(
+                                                postId = post.id,
+                                            ),
+                                        )
                                     },
                                     onReply = {
-                                        model.reduce(ProfileLoggedMviModel.Intent.WillOpenDetail)
-                                        detailOpener.openPostDetail(post)
+                                        model.reduce(
+                                            ProfileLoggedMviModel.Intent.WillOpenDetail(
+                                                postId = post.id,
+                                            ),
+                                        )
                                     },
                                     onOpenCommunity = { community, instance ->
                                         detailOpener.openCommunityDetail(community, instance)
@@ -494,9 +512,11 @@ object ProfileLoggedScreen : Tab {
                                         detailOpener.openCommunityDetail(community, instance)
                                     },
                                     onClick = {
-                                        detailOpener.openPostDetail(
-                                            post = PostModel(id = comment.postId),
-                                            highlightCommentId = comment.id,
+                                        model.reduce(
+                                            ProfileLoggedMviModel.Intent.WillOpenDetail(
+                                                postId = comment.postId,
+                                                commentId = comment.id,
+                                            ),
                                         )
                                     },
                                     onReply = {

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
@@ -217,9 +217,18 @@ class ProfileLoggedViewModel(
                 }
             }
 
-            ProfileLoggedMviModel.Intent.WillOpenDetail -> {
-                val state = postPaginationManager.extractState()
-                postNavigationManager.push(state)
+            is ProfileLoggedMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    if (intent.commentId == null) {
+                        val state = postPaginationManager.extractState()
+                        postNavigationManager.push(state)
+                    }
+                    emitEffect(
+                        ProfileLoggedMviModel.Effect.OpenDetail(
+                            postId = intent.postId,
+                            commentId = intent.commentId,
+                        ),
+                )
             }
 
             is ProfileLoggedMviModel.Intent.RestorePost -> {

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListMviModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListMviModel.kt
@@ -66,7 +66,9 @@ interface PostListMviModel :
 
         data object PauseZombieMode : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val id: Long,
+        ) : Intent
     }
 
     data class UiState(
@@ -106,6 +108,10 @@ interface PostListMviModel :
 
         data class ZombieModeTick(
             val index: Int,
+        ) : Effect
+
+        data class OpenDetail(
+            val post: PostModel,
         ) : Effect
     }
 }

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -188,6 +188,9 @@ class PostListScreen : Screen {
                                 }
                             }
                         }
+
+                        is PostListMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(effect.post)
                     }
                 }.launchIn(this)
         }
@@ -361,7 +364,7 @@ class PostListScreen : Screen {
                             key = {
                                 it.id.toString() + (
                                     it.updateDate ?: it.publishDate
-                                ) + it.read + uiState.isLogged
+                                ) + uiState.isLogged
                             },
                         ) { post ->
                             LaunchedEffect(post.id) {
@@ -504,9 +507,7 @@ class PostListScreen : Screen {
                                         botTagColor = uiState.botTagColor,
                                         meTagColor = uiState.meTagColor,
                                         onClick = {
-                                            model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
-                                            model.reduce(PostListMviModel.Intent.WillOpenDetail)
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(PostListMviModel.Intent.WillOpenDetail(post.id))
                                         },
                                         onDoubleClick =
                                             {
@@ -549,9 +550,9 @@ class PostListScreen : Screen {
                                         },
                                         onReply = {
                                             if (uiState.isLogged) {
-                                                model.reduce(PostListMviModel.Intent.MarkAsRead(post.id))
-                                                model.reduce(PostListMviModel.Intent.WillOpenDetail)
-                                                detailOpener.openPostDetail(post)
+                                                model.reduce(
+                                                    PostListMviModel.Intent.WillOpenDetail(post.id),
+                                                )
                                             }
                                         },
                                         onOpenImage = { url ->

--- a/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesMviModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesMviModel.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.VoteFormat
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PersonMentionModel
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 
 @Stable
 interface InboxRepliesMviModel :
@@ -30,6 +31,12 @@ interface InboxRepliesMviModel :
 
         data class DownVoteComment(
             val id: Long,
+        ) : Intent
+
+        data class WillOpenDetail(
+            val id: Long,
+            val post: PostModel,
+            val commentId: Long,
         ) : Intent
     }
 
@@ -58,5 +65,10 @@ interface InboxRepliesMviModel :
         ) : Effect
 
         data object BackToTop : Effect
+
+        data class OpenDetail(
+            val post: PostModel,
+            val commentId: Long,
+        ) : Effect
     }
 }

--- a/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
+++ b/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesScreen.kt
@@ -99,6 +99,12 @@ class InboxRepliesScreen : Tab {
                                 lazyListState.scrollToItem(0)
                             }
                         }
+
+                        is InboxRepliesMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(
+                                post = effect.post,
+                                highlightCommentId = effect.commentId,
+                            )
                     }
                 }.launchIn(this)
         }
@@ -138,7 +144,7 @@ class InboxRepliesScreen : Tab {
                 }
                 items(
                     items = uiState.replies,
-                    key = { it.id.toString() + it.read + uiState.unreadOnly },
+                    key = { it.id.toString() + uiState.unreadOnly },
                 ) { reply ->
 
                     @Composable
@@ -234,17 +240,12 @@ class InboxRepliesScreen : Tab {
                                 downVoteEnabled = uiState.downVoteEnabled,
                                 previewMaxLines = uiState.previewMaxLines,
                                 onClick = { post ->
-                                    if (!reply.read) {
-                                        model.reduce(
-                                            InboxRepliesMviModel.Intent.MarkAsRead(
-                                                read = true,
-                                                id = reply.id,
-                                            ),
-                                        )
-                                    }
-                                    detailOpener.openPostDetail(
-                                        post = post,
-                                        highlightCommentId = reply.comment.id,
+                                    model.reduce(
+                                        InboxRepliesMviModel.Intent.WillOpenDetail(
+                                            id = reply.id,
+                                            post = post,
+                                            commentId = reply.comment.id,
+                                        ),
                                     )
                                 },
                                 onOpenCreator = { user, instance ->

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailMviModel.kt
@@ -66,7 +66,10 @@ interface UserDetailMviModel :
 
         data object BlockInstance : Intent
 
-        data object WillOpenDetail : Intent
+        data class WillOpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Intent
 
         data class UpdateTags(
             val ids: List<Long>,
@@ -122,5 +125,10 @@ interface UserDetailMviModel :
         ) : Effect
 
         data object BackToTop : Effect
+
+        data class OpenDetail(
+            val postId: Long,
+            val commentId: Long? = null,
+        ) : Effect
     }
 }

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -197,6 +197,12 @@ class UserDetailScreen(
                                 }
                             }
                         }
+
+                        is UserDetailMviModel.Effect.OpenDetail ->
+                            detailOpener.openPostDetail(
+                                post = PostModel(id = effect.postId),
+                                highlightCommentId = effect.commentId,
+                            )
                     }
                 }.launchIn(this)
         }
@@ -546,7 +552,7 @@ class UserDetailScreen(
                         items(
                             items = uiState.posts,
                             key = {
-                                it.id.toString() + (it.updateDate ?: it.publishDate) + it.read
+                                it.id.toString() + (it.updateDate ?: it.publishDate)
                             },
                         ) { post ->
 
@@ -665,8 +671,11 @@ class UserDetailScreen(
                                         actionButtonsActive = uiState.isLogged,
                                         downVoteEnabled = uiState.downVoteEnabled,
                                         onClick = {
-                                            model.reduce(UserDetailMviModel.Intent.WillOpenDetail)
-                                            detailOpener.openPostDetail(post)
+                                            model.reduce(
+                                                UserDetailMviModel.Intent.WillOpenDetail(
+                                                    postId = post.id,
+                                                ),
+                                            )
                                         },
                                         onDoubleClick =
                                             {
@@ -709,8 +718,11 @@ class UserDetailScreen(
                                         },
                                         onReply =
                                             {
-                                                model.reduce(UserDetailMviModel.Intent.WillOpenDetail)
-                                                detailOpener.openPostDetail(post)
+                                                model.reduce(
+                                                    UserDetailMviModel.Intent.WillOpenDetail(
+                                                        postId = post.id,
+                                                    ),
+                                                )
                                             }.takeIf { uiState.isLogged && !isOnOtherInstance },
                                         onOpenImage = { url ->
                                             navigationCoordinator.pushScreen(
@@ -969,9 +981,11 @@ class UserDetailScreen(
                                         downVoteEnabled = uiState.downVoteEnabled,
                                         actionButtonsActive = uiState.isLogged,
                                         onClick = {
-                                            detailOpener.openPostDetail(
-                                                post = PostModel(id = comment.postId),
-                                                highlightCommentId = comment.id,
+                                            model.reduce(
+                                                UserDetailMviModel.Intent.WillOpenDetail(
+                                                    postId = comment.postId,
+                                                    commentId = comment.id,
+                                                ),
                                             )
                                         },
                                         onImageClick = { url ->

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -308,10 +308,19 @@ class UserDetailViewModel(
             UserDetailMviModel.Intent.Block -> blockUser()
             UserDetailMviModel.Intent.BlockInstance -> blockInstance()
 
-            UserDetailMviModel.Intent.WillOpenDetail -> {
-                val state = postPaginationManager.extractState()
-                postNavigationManager.push(state)
-            }
+            is UserDetailMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    if (intent.commentId == null) {
+                        val state = postPaginationManager.extractState()
+                        postNavigationManager.push(state)
+                    }
+                    emitEffect(
+                        UserDetailMviModel.Effect.OpenDetail(
+                            postId = intent.postId,
+                            commentId = intent.commentId,
+                        ),
+                    )
+                }
 
             is UserDetailMviModel.Intent.AddUserTag ->
                 addUserTag(name = intent.name, color = intent.color)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR deals with opening post detail differently to avoid a concurrency issue (due to the post being marked as read before the view model could update its state due to entering the paused state).

## Additional notes
<!-- Anything to declare for code review? -->
This is a tentative fix for #239.
