### PR TITLE
fix: simplify video and image post URL matching

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -746,9 +746,7 @@ private fun ExtendedPost(
                             if (postLinkUrl.isNotEmpty() && settings.openPostWebPageOnImageClick) {
                                 uriHandler.openUri(postLinkUrl)
                             } else {
-                                val urlToOpen =
-                                    post.url?.takeIf { it.looksLikeAnImage } ?: post.imageUrl
-                                onOpenImage?.invoke(urlToOpen)
+                                onOpenImage?.invoke(post.imageUrl)
                             }
                         },
                         onDoubleClick = onDoubleClick,

--- a/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/PostModel.kt
+++ b/domain/lemmy/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/data/PostModel.kt
@@ -33,9 +33,7 @@ data class PostModel(
 )
 
 val PostModel.imageUrl: String
-    get() =
-        thumbnailUrl?.takeIf { it.isNotEmpty() }
-            ?: url?.takeIf { it.looksLikeAnImage }.orEmpty()
+    get() = (url?.takeIf { it.looksLikeAnImage } ?: thumbnailUrl).orEmpty()
 
 val PostModel.videoUrl: String
-    get() = url?.takeIf { it.looksLikeAVideo }?.takeIf { it.isNotEmpty() }.orEmpty()
+    get() = url?.takeIf { it.looksLikeAVideo }.orEmpty()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR  iterates over #154 because a similar bug was reintroduced and the app failed opening the same post reported in #142.

This was tested both for Compact and Card layouts.
