### PR TITLE
chore: remove arg name for single param invocations

### DIFF
--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/urlhandler/DefaultPostProcessor.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/urlhandler/DefaultPostProcessor.kt
@@ -21,7 +21,7 @@ internal class DefaultPostProcessor(
                 )
 
             if (resolved != null) {
-                detailOpener.openPostDetail(post = resolved)
+                detailOpener.openPostDetail(resolved)
                 true
             } else {
                 val (post, instance) = urlDecoder.getPost(url)

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/urlhandler/DefaultUserProcessor.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/urlhandler/DefaultUserProcessor.kt
@@ -20,7 +20,7 @@ internal class DefaultUserProcessor(
                     auth = auth,
                 )
             if (resolved != null) {
-                detailOpener.openUserDetail(user = resolved)
+                detailOpener.openUserDetail(resolved)
                 true
             } else {
                 val user = urlDecoder.getUser(url)

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -266,7 +266,7 @@ class CommunityDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleDownVotePost(post = post)
+                    toggleDownVotePost(post)
                 }
             }
 
@@ -279,7 +279,7 @@ class CommunityDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleSavePost(post = post)
+                    toggleSavePost(post)
                 }
             }
 
@@ -288,7 +288,7 @@ class CommunityDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleUpVotePost(post = post)
+                    toggleUpVotePost(post)
                 }
             }
 
@@ -302,12 +302,12 @@ class CommunityDetailViewModel(
             is CommunityDetailMviModel.Intent.MarkAsRead ->
                 screenModelScope.launch {
                     markAsRead(uiState.value.posts.first { it.id == intent.id })
-            }
+                }
 
             CommunityDetailMviModel.Intent.ClearRead -> clearRead()
             is CommunityDetailMviModel.Intent.Hide -> {
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    hide(post = post)
+                    hide(post)
                 }
             }
 
@@ -332,21 +332,21 @@ class CommunityDetailViewModel(
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        feature(post = post)
+                        feature(post)
                     }
 
             is CommunityDetailMviModel.Intent.AdminFeaturePost ->
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        featureLocal(post = post)
+                        featureLocal(post)
                     }
 
             is CommunityDetailMviModel.Intent.ModLockPost ->
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        lock(post = post)
+                        lock(post)
                     }
 
             is CommunityDetailMviModel.Intent.ModToggleModUser -> {
@@ -376,8 +376,8 @@ class CommunityDetailViewModel(
                             markAsRead(post)
                             val state = postPaginationManager.extractState()
                             postNavigationManager.push(state)
-                    }
-            }
+                        }
+                }
 
             CommunityDetailMviModel.Intent.UnhideCommunity -> {
                 unhideCommunity()
@@ -421,7 +421,10 @@ class CommunityDetailViewModel(
         val auth = identityRepository.authToken.value
         val accountId = accountRepository.getActive()?.id
         val isFavorite =
-            favoriteCommunityRepository.getBy(accountId, currentState.community.id) != null
+            favoriteCommunityRepository.getBy(
+                accountId = accountId,
+                communityId = currentState.community.id,
+            ) != null
         val refreshedCommunity =
             communityRepository
                 .get(

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsViewModel.kt
@@ -134,7 +134,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleUpVote(post = post)
+                    toggleUpVote(post)
                 }
             }
 
@@ -143,7 +143,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleDownVote(post = post)
+                    toggleDownVote(post)
                 }
             }
 
@@ -152,7 +152,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleSave(post = post)
+                    toggleSave(post)
                 }
             }
 
@@ -160,21 +160,21 @@ class FilteredContentsViewModel(
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        feature(post = post)
+                        feature(post)
                     }
 
             is FilteredContentsMviModel.Intent.AdminFeaturePost ->
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        featureLocal(post = post)
+                        featureLocal(post)
                     }
 
             is FilteredContentsMviModel.Intent.ModLockPost ->
                 uiState.value.posts
                     .firstOrNull { it.id == intent.id }
                     ?.also { post ->
-                        lock(post = post)
+                        lock(post)
                     }
 
             is FilteredContentsMviModel.Intent.UpVoteComment -> {
@@ -182,7 +182,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.commentId }?.also { comment ->
-                    toggleUpVoteComment(comment = comment)
+                    toggleUpVoteComment(comment)
                 }
             }
 
@@ -191,7 +191,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.commentId }?.also { comment ->
-                    toggleDownVoteComment(comment = comment)
+                    toggleDownVoteComment(comment)
                 }
             }
 
@@ -200,7 +200,7 @@ class FilteredContentsViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.commentId }?.also { comment ->
-                    toggleSaveComment(comment = comment)
+                    toggleSaveComment(comment)
                 }
             }
 

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -140,7 +140,7 @@ class MultiCommunityScreen(
                         }
 
                         is MultiCommunityMviModel.Effect.OpenDetail ->
-                            detailOpener.openPostDetail(post = effect.post)
+                            detailOpener.openPostDetail(effect.post)
                     }
                 }.launchIn(this)
         }

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -186,7 +186,7 @@ class MultiCommunityViewModel(
                 if (intent.feedback) {
                     hapticFeedback.vibrate()
                 }
-                toggleUpVote(post = uiState.value.posts.first { it.id == intent.id })
+                toggleUpVote(uiState.value.posts.first { it.id == intent.id })
             }
 
             MultiCommunityMviModel.Intent.ClearRead -> clearRead()

--- a/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
+++ b/unit/myaccount/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/myaccount/ProfileLoggedViewModel.kt
@@ -168,7 +168,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleDownVoteComment(comment = comment)
+                    toggleDownVoteComment(comment)
                 }
             }
 
@@ -177,7 +177,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleDownVotePost(post = post)
+                    toggleDownVotePost(post)
                 }
             }
 
@@ -186,7 +186,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleSaveComment(comment = comment)
+                    toggleSaveComment(comment)
                 }
             }
 
@@ -195,7 +195,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleSavePost(post = post)
+                    toggleSavePost(post)
                 }
             }
 
@@ -204,7 +204,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleUpVoteComment(comment = comment)
+                    toggleUpVoteComment(comment)
                 }
             }
 
@@ -213,7 +213,7 @@ class ProfileLoggedViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleUpVotePost(post = post)
+                    toggleUpVotePost(post)
                 }
             }
 
@@ -228,8 +228,8 @@ class ProfileLoggedViewModel(
                             postId = intent.postId,
                             commentId = intent.commentId,
                         ),
-                )
-            }
+                    )
+                }
 
             is ProfileLoggedMviModel.Intent.RestorePost -> {
                 restorePost(intent.id)

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -214,17 +214,13 @@ class PostDetailViewModel(
             lemmyValueCache.isCurrentUserAdmin
                 .onEach { value ->
                     updateState {
-                        it.copy(
-                            isAdmin = value,
-                        )
+                        it.copy(isAdmin = value)
                     }
                 }.launchIn(this)
             lemmyValueCache.isDownVoteEnabled
                 .onEach { value ->
                     updateState {
-                        it.copy(
-                            downVoteEnabled = value,
-                        )
+                        it.copy(downVoteEnabled = value)
                     }
                 }.launchIn(this)
 
@@ -246,7 +242,10 @@ class PostDetailViewModel(
                 }
                 // reset unread comments
                 notificationCenter.send(
-                    event = NotificationCenterEvent.PostUpdated(updatedPost.copy(unreadComments = 0)),
+                    event =
+                        NotificationCenterEvent.PostUpdated(
+                            updatedPost.copy(unreadComments = 0),
+                        ),
                 )
             }
 
@@ -272,9 +271,7 @@ class PostDetailViewModel(
                 val admins =
                     uiState.value.post.community
                         .let { community ->
-                            siteRepository.getAdmins(
-                                otherInstance = community?.host,
-                            )
+                            siteRepository.getAdmins(otherInstance = community?.host)
                         }
 
                 val sortTypes =
@@ -356,7 +353,7 @@ class PostDetailViewModel(
                 uiState.value.comments
                     .firstOrNull { it.id == intent.commentId }
                     ?.also { comment ->
-                        toggleDownVoteComment(comment = comment)
+                        toggleDownVoteComment(comment)
                     }
             }
 
@@ -364,7 +361,7 @@ class PostDetailViewModel(
                 if (intent.feedback) {
                     hapticFeedback.vibrate()
                 }
-                toggleDownVotePost(post = uiState.value.post)
+                toggleDownVotePost(uiState.value.post)
             }
 
             is PostDetailMviModel.Intent.SaveComment -> {
@@ -374,7 +371,7 @@ class PostDetailViewModel(
                 uiState.value.comments
                     .firstOrNull { it.id == intent.commentId }
                     ?.also { comment ->
-                        toggleSaveComment(comment = comment)
+                        toggleSaveComment(comment)
                     }
             }
 
@@ -382,7 +379,7 @@ class PostDetailViewModel(
                 if (intent.feedback) {
                     hapticFeedback.vibrate()
                 }
-                toggleSavePost(post = intent.post)
+                toggleSavePost(intent.post)
             }
 
             is PostDetailMviModel.Intent.Share -> {
@@ -396,7 +393,7 @@ class PostDetailViewModel(
                 uiState.value.comments
                     .firstOrNull { it.id == intent.commentId }
                     ?.also { comment ->
-                        toggleUpVoteComment(comment = comment)
+                        toggleUpVoteComment(comment)
                     }
             }
 
@@ -404,7 +401,7 @@ class PostDetailViewModel(
                 if (intent.feedback) {
                     hapticFeedback.vibrate()
                 }
-                toggleUpVotePost(post = uiState.value.post)
+                toggleUpVotePost(uiState.value.post)
             }
 
             is PostDetailMviModel.Intent.FetchMoreComments -> {

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/utils/CommentUtils.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/utils/CommentUtils.kt
@@ -20,7 +20,7 @@ internal fun List<CommentModel>.sortToNestedOrder(ancestorId: Long? = null): Lis
     // populate a memo for quick access
     val memo = mutableMapOf<Long, CommentNode>()
     for (comment in this) {
-        val node = CommentNode.Actual(comment = comment)
+        val node = CommentNode.Actual(comment)
         memo[comment.id] = node
     }
 
@@ -44,22 +44,23 @@ internal fun List<CommentModel>.sortToNestedOrder(ancestorId: Long? = null): Lis
         )
 
     // linearize the tree and convert to comment list
-    return mutableListOf<CommentNode>().apply {
-        linearize(
-            node = root,
-            list = this,
-        )
-    }.map { node ->
-        when (node) {
-            is CommentNode.Actual -> node.comment
-            is CommentNode.Placeholder ->
-                CommentModel(
-                    id = node.id,
-                    text = "",
-                    removed = true,
-                )
+    return mutableListOf<CommentNode>()
+        .apply {
+            linearize(
+                node = root,
+                list = this,
+            )
+        }.map { node ->
+            when (node) {
+                is CommentNode.Actual -> node.comment
+                is CommentNode.Placeholder ->
+                    CommentModel(
+                        id = node.id,
+                        text = "",
+                        removed = true,
+                    )
+            }
         }
-    }
 }
 
 data class PlaceholderComment(
@@ -146,20 +147,20 @@ private fun connectNodesAndGeneratePlaceholders(
 private fun joinForestUnderSingleRoot(
     ancestorId: Long?,
     memo: Map<Long, CommentNode>,
-): CommentNode {
-    return CommentNode.Placeholder(
-        missingComment =
-            PlaceholderComment(
-                id = 0,
-                path = "",
-            ),
-    ).apply {
-        children +=
-            memo.values.filter { node ->
-                node.parent?.id == ancestorId
-            }
-    }
-}
+): CommentNode =
+    CommentNode
+        .Placeholder(
+            missingComment =
+                PlaceholderComment(
+                    id = 0,
+                    path = "",
+                ),
+        ).apply {
+            children +=
+                memo.values.filter { node ->
+                    node.parent?.id == ancestorId
+                }
+        }
 
 private fun linearize(
     node: CommentNode,

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
@@ -240,7 +240,7 @@ class PostListViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleDownVote(post = post)
+                    toggleDownVote(post)
                 }
             }
 
@@ -249,7 +249,7 @@ class PostListViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleSave(post = post)
+                    toggleSave(post)
                 }
             }
 
@@ -258,7 +258,7 @@ class PostListViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleUpVote(post = post)
+                    toggleUpVote(post)
                 }
             }
 
@@ -271,14 +271,14 @@ class PostListViewModel(
             is PostListMviModel.Intent.MarkAsRead ->
                 screenModelScope.launch {
                     uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                        markAsRead(post = post)
+                        markAsRead(post)
                     }
                 }
 
             PostListMviModel.Intent.ClearRead -> clearRead()
             is PostListMviModel.Intent.Hide -> {
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    hide(post = post)
+                    hide(post)
                 }
             }
 

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -239,7 +239,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleDownVoteComment(comment = comment)
+                    toggleDownVoteComment(comment)
                 }
             }
 
@@ -248,9 +248,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleDownVote(
-                        post = post,
-                    )
+                    toggleDownVote(post)
                 }
             }
 
@@ -270,7 +268,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleSaveComment(comment = comment)
+                    toggleSaveComment(comment)
                 }
             }
 
@@ -279,7 +277,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleSave(post = post)
+                    toggleSave(post)
                 }
             }
 
@@ -288,7 +286,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.comments.firstOrNull { it.id == intent.id }?.also { comment ->
-                    toggleUpVoteComment(comment = comment)
+                    toggleUpVoteComment(comment)
                 }
             }
 
@@ -297,7 +295,7 @@ class UserDetailViewModel(
                     hapticFeedback.vibrate()
                 }
                 uiState.value.posts.firstOrNull { it.id == intent.id }?.also { post ->
-                    toggleUpVote(post = post)
+                    toggleUpVote(post)
                 }
             }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes argument names for method invocations with a single param where there is no disambiguation needed. Additionally, it contains some other minor stylistic improvements, removing redundant newlines and the like.

## Additional notes
<!-- Anything to declare for code review? -->
I realized this was creating confusion to newcomers, thinking the presence or absence of an argument name made a difference where it didn't.
