### PR TITLE
fix: disallow "top" sort type expansion for comments in post detail, user detail, explore

### DIFF
--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -70,7 +69,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
@@ -198,10 +196,6 @@ class CommunityDetailScreen(
                 }
             }
         var itemIdToDelete by remember { mutableStateOf<Long?>(null) }
-        val statusBarInset =
-            with(LocalDensity.current) {
-                WindowInsets.statusBars.getTop(this)
-            }
         var selectLanguageDialogOpen by remember { mutableStateOf(false) }
         var unsubscribeConfirmDialogOpen by remember { mutableStateOf(false) }
         var deleteConfirmDialogOpen by remember { mutableStateOf(false) }

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -866,7 +866,7 @@ class ExploreScreen(
         if (sortBottomSheetOpened) {
             SortBottomSheet(
                 values = uiState.availableSortTypes,
-                expandTop = true,
+                expandTop = uiState.resultType != SearchResultType.Comments,
                 onSelected = { value ->
                     sortBottomSheetOpened = false
                     if (value != null) {

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreViewModel.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreViewModel.kt
@@ -223,7 +223,12 @@ class ExploreViewModel(
     }
 
     private suspend fun updateAvailableSortTypes() {
-        val sortTypes = getSortTypesUseCase.getTypesForPosts()
+        val sortTypes =
+            if (uiState.value.resultType == SearchResultType.Comments) {
+                getSortTypesUseCase.getTypesForComments(otherInstance = otherInstance)
+            } else {
+                getSortTypesUseCase.getTypesForPosts(otherInstance = otherInstance)
+            }
         updateState { it.copy(availableSortTypes = sortTypes) }
     }
 
@@ -362,6 +367,7 @@ class ExploreViewModel(
         screenModelScope.launch {
             updateState { it.copy(resultType = value) }
             emitEffect(ExploreMviModel.Effect.BackToTop)
+            updateAvailableSortTypes()
             refresh()
         }
     }

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -206,10 +205,6 @@ class PostDetailScreen(
             }
         var postToDelete by remember { mutableStateOf<Unit?>(null) }
         var commentIdToDelete by remember { mutableStateOf<Long?>(null) }
-        val statusBarInset =
-            with(LocalDensity.current) {
-                WindowInsets.statusBars.getTop(this)
-            }
         val bottomNavigationInsetPx =
             with(LocalDensity.current) {
                 WindowInsets.navigationBars.getBottom(this)
@@ -2006,7 +2001,7 @@ class PostDetailScreen(
         if (sortBottomSheetOpened) {
             SortBottomSheet(
                 values = uiState.availableSortTypes,
-                expandTop = true,
+                expandTop = false,
                 onSelected = { value ->
                     sortBottomSheetOpened = false
                     if (value != null) {

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -1259,7 +1259,7 @@ class UserDetailScreen(
         if (sortBottomSheetOpened || defaultSortBottomSheetOpened) {
             SortBottomSheet(
                 values = uiState.availableSortTypes,
-                expandTop = true,
+                expandTop = uiState.section == UserDetailSection.Posts,
                 onSelected = { value ->
                     val wasDefaultSortBottomSheetOpened = defaultSortBottomSheetOpened
                     sortBottomSheetOpened = false


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes the sort bottom sheet when used to select a value suitable for comments (i.e. with no "top" subselection).

