### PR TITLE
fix: add bar theme option only if supported

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -13,6 +13,9 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiTheme
 
 internal class DefaultBarColorProvider : BarColorProvider {
+    override val isBarThemeSupported: Boolean
+        get() = Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM
+
     @Composable
     override fun setBarColorAccordingToTheme(
         theme: UiTheme,
@@ -40,19 +43,17 @@ internal class DefaultBarColorProvider : BarColorProvider {
                         UiBarTheme.Transparent -> baseColor.copy(alpha = 0.01f)
                         else -> baseColor
                     }.toArgb()
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                if (isBarThemeSupported) {
                     statusBarColor = barColor
                     navigationBarColor = barColor
                 }
 
-                if (barTheme != UiBarTheme.Solid) {
-                    WindowCompat.setDecorFitsSystemWindows(this, false)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-                            isStatusBarContrastEnforced = true
-                        }
-                        isNavigationBarContrastEnforced = true
+                WindowCompat.setDecorFitsSystemWindows(this, false)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                        isStatusBarContrastEnforced = true
                     }
+                    isNavigationBarContrastEnforced = true
                 }
 
                 WindowCompat.getInsetsController(this, decorView).apply {

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/BarColorProvider.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/BarColorProvider.kt
@@ -5,6 +5,8 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiTheme
 
 interface BarColorProvider {
+    val isBarThemeSupported: Boolean
+
     @Composable
     fun setBarColorAccordingToTheme(
         theme: UiTheme,

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -10,6 +10,8 @@ import platform.UIKit.UIStatusBarStyleLightContent
 import platform.UIKit.setStatusBarStyle
 
 internal class DefaultBarColorProvider : BarColorProvider {
+    override val isBarThemeSupported = false
+
     @Composable
     override fun setBarColorAccordingToTheme(
         theme: UiTheme,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -126,6 +126,7 @@ interface AdvancedSettingsMviModel :
         val alternateMarkdownRenderingItemVisible: Boolean = false,
         val enableAlternateMarkdownRendering: Boolean = false,
         val restrictLocalUserSearch: Boolean = false,
+        val isBarThemeSupported: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -199,13 +199,15 @@ class AdvancedSettingsScreen : Screen {
                     )
 
                     // system bar theme
-                    SettingsRow(
-                        title = LocalStrings.current.settingsBarTheme,
-                        value = uiState.systemBarTheme.toReadableName(),
-                        onTap = {
-                            barThemeBottomSheetOpened = true
-                        },
-                    )
+                    if (uiState.isBarThemeSupported) {
+                        SettingsRow(
+                            title = LocalStrings.current.settingsBarTheme,
+                            value = uiState.systemBarTheme.toReadableName(),
+                            onTap = {
+                                barThemeBottomSheetOpened = true
+                            },
+                        )
+                    }
 
                     // bottom navigation hiding
                     SettingsSwitchRow(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toUiBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.repository.ThemeRepository
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.BarColorProvider
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SelectNumberBottomSheetType
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.toSelectNumberBottomSheetType
@@ -52,6 +53,7 @@ class AdvancedSettingsViewModel(
     private val exportSettings: ExportSettingsUseCase,
     private val appConfigStore: AppConfigStore,
     private val appInfoRepository: AppInfoRepository,
+    private val barColorProvider: BarColorProvider,
 ) : DefaultMviModel<AdvancedSettingsMviModel.Intent, AdvancedSettingsMviModel.UiState, AdvancedSettingsMviModel.Effect>(
         initialState = AdvancedSettingsMviModel.UiState(),
     ),
@@ -164,6 +166,7 @@ class AdvancedSettingsViewModel(
                     openPostWebPageOnImageClick = settings.openPostWebPageOnImageClick,
                     enableAlternateMarkdownRendering = settings.enableAlternateMarkdownRendering,
                     restrictLocalUserSearch = settings.restrictLocalUserSearch,
+                    isBarThemeSupported = barColorProvider.isBarThemeSupported,
                 )
             }
         }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/di/SettingsTabModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/di/SettingsTabModule.kt
@@ -29,6 +29,7 @@ val settingsTabModule =
                     exportSettings = instance(),
                     appConfigStore = instance(),
                     appInfoRepository = instance(),
+                    barColorProvider = instance(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes the UI bar theme option from the advanced settings screen because it has no effect on Android >= 15 (and this is intended).