### PR TITLE
fix: add workaround to make it possible to see quotes spanning multiple paragraphs

### DIFF
--- a/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
+++ b/core/markdown/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/markdown/Utils.kt
@@ -75,12 +75,12 @@ private fun String.quoteFixUp(): String =
         lines().forEach { originalLine ->
             val cleanLine =
                 originalLine
-                    // removes list inside quotes
+                    // fix bug due to which list inside quotes are not rendered correctly
                     .replace(Regex("^>-"), "> •")
                     .replace(Regex("^> -"), "> •")
                     .replace(Regex("^> \\*"), "> •")
-                    // empty quotes
-                    .replace(Regex("^>\\s*$"), " \n")
+                    // fix bug due to which only first paragraph is shown in quote if "> \n" occurs
+                    .replace(Regex("^>\\s*$"), "> ")
             if (cleanLine.isNotEmpty()) {
                 finalLines += cleanLine
             }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR solves a bug introduced in an attempt to work around an issue in the Multiplatform Markdown Renderer library due to which multi-paragraph quotes were cut off after the first paragraph.

Given that the `> \n` sequence apparently breaks the rendering and adding a newline, in turn, breaks the paragraph structure, the only viable solution was to insert an non-breakable space into the character stream.

<details><summary><h4>Related PRs</h4></summary>

- #261,
- #259 
- #234,
- #122
- #62
</details>
