### PR TITLE
chore: add feddit.org to list of default instances

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultInstanceSelectionRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultInstanceSelectionRepository.kt
@@ -10,6 +10,7 @@ private val DEFAULT_INSTANCES =
     listOf(
         "discuss.tchncs.de",
         "feddit.it",
+        "feddit.org",
         "infosec.pub",
         "lemm.ee",
         "lemmy.blahaj.zone",


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds `feddit.org` to the list of default instances (`feddit.de` was removed by #83 and never replaced).
