### PR TITLE
feat: add option to not mark posts as read on interaction

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/l10n/Strings.kt
@@ -433,6 +433,8 @@ interface Strings {
     val settingsManageBanSectionStopWords: String @Composable get
     val settingsManageBanStopWordPlaceholder: String @Composable get
     val settingsMarkAsReadWhileScrolling: String @Composable get
+    val settingsMarkAsReadOnInteraction: String @Composable get
+    val settingsMarkAsReadOnInteractionSubtitle: String @Composable get
     val settingsMediaList: String @Composable get
     val settingsNavigationBarTitlesVisible: String @Composable get
     val settingsOpenUrlExternal: String @Composable get

--- a/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepositoryTest.kt
@@ -109,7 +109,7 @@ class DefaultSettingsRepositoryTest {
 
             verify {
                 queries.create(
-                    theme = model.theme?.toLong(),
+                    theme = model.theme.toLong(),
                     uiFontScale = model.uiFontScale.toDouble(),
                     uiFontFamily = model.uiFontFamily.toLong(),
                     titleFontScale = model.contentFontScale.title.toDouble(),
@@ -175,6 +175,7 @@ class DefaultSettingsRepositoryTest {
                     randomThemeColor = if (model.randomThemeColor) 1 else 0,
                     openPostWebPageOnImageClick = if (model.openPostWebPageOnImageClick) 1 else 0,
                     restrictLocalUserSearch = if (model.restrictLocalUserSearch) 1 else 0,
+                    markAsReadOnInteraction = if (model.markAsReadOnInteraction) 1 else 0,
                 )
             }
         }
@@ -187,7 +188,7 @@ class DefaultSettingsRepositoryTest {
 
             verify {
                 queries.update(
-                    theme = model.theme?.toLong(),
+                    theme = model.theme.toLong(),
                     uiFontScale = model.uiFontScale.toDouble(),
                     uiFontFamily = model.uiFontFamily.toLong(),
                     titleFontScale = model.contentFontScale.title.toDouble(),
@@ -253,6 +254,7 @@ class DefaultSettingsRepositoryTest {
                     randomThemeColor = if (model.randomThemeColor) 1 else 0,
                     openPostWebPageOnImageClick = if (model.openPostWebPageOnImageClick) 1 else 0,
                     restrictLocalUserSearch = if (model.restrictLocalUserSearch) 1 else 0,
+                    markAsReadOnInteraction = if (model.markAsReadOnInteraction) 1 else 0,
                 )
             }
         }
@@ -268,7 +270,7 @@ class DefaultSettingsRepositoryTest {
             sut.updateSettings(model, null)
 
             coVerify {
-                keyStore.save("uiTheme", model.theme ?: 0)
+                keyStore.save("uiTheme", model.theme)
                 keyStore.save("uiFontFamily", model.uiFontFamily)
                 keyStore.save("uiFontSize", model.uiFontScale)
                 keyStore.save("titleFontSize", model.contentFontScale.title)
@@ -462,5 +464,6 @@ class DefaultSettingsRepositoryTest {
         randomThemeColor = if (randomThemeColor) 1 else 0,
         openPostWebPageOnImageClick = if (openPostWebPageOnImageClick) 1 else 0,
         restrictLocalUserSearch = if (restrictLocalUserSearch) 1 else 0,
+        markAsReadOnInteraction = if (restrictLocalUserSearch) 1 else 0,
     )
 }

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/SettingsModel.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/data/SettingsModel.kt
@@ -70,4 +70,5 @@ data class SettingsModel(
     val openPostWebPageOnImageClick: Boolean = true,
     val enableAlternateMarkdownRendering: Boolean = false,
     val restrictLocalUserSearch: Boolean = false,
+    val markAsReadOnInteraction: Boolean = true,
 )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultSettingsRepository.kt
@@ -170,6 +170,7 @@ internal class DefaultSettingsRepository(
             randomThemeColor = if (settings.randomThemeColor) 1L else 0L,
             openPostWebPageOnImageClick = if (settings.openPostWebPageOnImageClick) 1L else 0L,
             restrictLocalUserSearch = if (settings.restrictLocalUserSearch) 1L else 0L,
+            markAsReadOnInteraction = if (settings.markAsReadOnInteraction) 1L else 0L,
         )
     }
 
@@ -462,6 +463,7 @@ internal class DefaultSettingsRepository(
                 randomThemeColor = if (settings.randomThemeColor) 1L else 0L,
                 openPostWebPageOnImageClick = if (settings.openPostWebPageOnImageClick) 1L else 0L,
                 restrictLocalUserSearch = if (settings.restrictLocalUserSearch) 1L else 0L,
+                markAsReadOnInteraction = if (settings.markAsReadOnInteraction) 1L else 0L,
             )
         }
     }
@@ -570,4 +572,5 @@ private fun GetBy.toModel() =
         randomThemeColor = randomThemeColor == 1L,
         openPostWebPageOnImageClick = openPostWebPageOnImageClick == 1L,
         restrictLocalUserSearch = restrictLocalUserSearch == 1L,
+        markAsReadOnInteraction = markAsReadOnInteraction == 1L,
     )

--- a/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/settings.sq
+++ b/core/persistence/src/commonMain/sqldelight/com/livefast/eattrash/raccoonforlemmy/core/persistence/settings.sq
@@ -66,6 +66,7 @@ CREATE TABLE SettingsEntity (
     randomThemeColor INTEGER NOT NULL DEFAULT 1,
     openPostWebPageOnImageClick INTEGER NOT NULL DEFAULT 1,
     restrictLocalUserSearch INTEGER NOT NULL DEFAULT 0,
+    markAsReadOnInteraction INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (account_id) REFERENCES AccountEntity(id) ON DELETE CASCADE,
     UNIQUE(account_id)
 );
@@ -137,8 +138,10 @@ INSERT OR IGNORE INTO SettingsEntity (
     randomThemeColor,
     openPostWebPageOnImageClick,
     account_id,
-    restrictLocalUserSearch
+    restrictLocalUserSearch,
+    markAsReadOnInteraction
 ) VALUES (
+    ?,
     ?,
     ?,
     ?,
@@ -273,7 +276,8 @@ SET theme = ?,
     useAvatarAsProfileNavigationIcon = ?,
     randomThemeColor = ?,
     openPostWebPageOnImageClick = ?,
-    restrictLocalUserSearch = ?
+    restrictLocalUserSearch = ?,
+    markAsReadOnInteraction = ?
 WHERE account_id = ?;
 
 getBy:
@@ -343,6 +347,7 @@ SELECT
     useAvatarAsProfileNavigationIcon,
     randomThemeColor,
     openPostWebPageOnImageClick,
-    restrictLocalUserSearch
+    restrictLocalUserSearch,
+    markAsReadOnInteraction
 FROM SettingsEntity
 WHERE account_id = ?;

--- a/core/persistence/src/commonMain/sqldelight/migrations/42.sqm
+++ b/core/persistence/src/commonMain/sqldelight/migrations/42.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE SettingsEntity
+ADD COLUMN markAsReadOnInteraction INTEGER NOT NULL DEFAULT 1;

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -33,6 +33,10 @@ interface AdvancedSettingsMviModel :
             val value: Boolean,
         ) : Intent
 
+        data class ChangeMarkAsReadOnInteraction(
+            val value: Boolean,
+        ) : Intent
+
         data class ChangeNavBarTitlesVisible(
             val value: Boolean,
         ) : Intent
@@ -127,6 +131,7 @@ interface AdvancedSettingsMviModel :
         val enableAlternateMarkdownRendering: Boolean = false,
         val restrictLocalUserSearch: Boolean = false,
         val isBarThemeSupported: Boolean = false,
+        val markAsReadOnInteraction: Boolean = true,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -362,6 +362,19 @@ class AdvancedSettingsScreen : Screen {
                                 )
                             },
                         )
+                        // mark as read on vote or save
+                        SettingsSwitchRow(
+                            title = LocalStrings.current.settingsMarkAsReadOnInteraction,
+                            subtitle = LocalStrings.current.settingsMarkAsReadOnInteractionSubtitle,
+                            value = uiState.markAsReadOnInteraction,
+                            onValueChanged = { value ->
+                                model.reduce(
+                                    AdvancedSettingsMviModel.Intent.ChangeMarkAsReadOnInteraction(
+                                        value,
+                                    ),
+                                )
+                            },
+                        )
                     }
 
                     // zombie mode interval

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -167,6 +167,7 @@ class AdvancedSettingsViewModel(
                     enableAlternateMarkdownRendering = settings.enableAlternateMarkdownRendering,
                     restrictLocalUserSearch = settings.restrictLocalUserSearch,
                     isBarThemeSupported = barColorProvider.isBarThemeSupported,
+                    markAsReadOnInteraction = settings.markAsReadOnInteraction,
                 )
             }
         }
@@ -189,6 +190,9 @@ class AdvancedSettingsViewModel(
 
             is AdvancedSettingsMviModel.Intent.ChangeMarkAsReadWhileScrolling ->
                 changeMarkAsReadWhileScrolling(intent.value)
+
+            is AdvancedSettingsMviModel.Intent.ChangeMarkAsReadOnInteraction ->
+                changeMarkAsReadOnInteraction(intent.value)
 
             is AdvancedSettingsMviModel.Intent.ChangeSearchPostTitleOnly ->
                 changeSearchPostTitleOnly(intent.value)
@@ -274,6 +278,15 @@ class AdvancedSettingsViewModel(
             updateState { it.copy(markAsReadWhileScrolling = value) }
             val settings =
                 settingsRepository.currentSettings.value.copy(markAsReadWhileScrolling = value)
+            saveSettings(settings)
+        }
+    }
+
+    private fun changeMarkAsReadOnInteraction(value: Boolean) {
+        screenModelScope.launch {
+            updateState { it.copy(markAsReadOnInteraction = value) }
+            val settings =
+                settingsRepository.currentSettings.value.copy(markAsReadOnInteraction = value)
             saveSettings(settings)
         }
     }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="settings_manage_ban_section_instances">Instances</string>
     <string name="settings_manage_ban_section_stop_words">Words</string>
     <string name="settings_manage_ban_stop_word_placeholder">Forbidden expression</string>
+    <string name="settings_mark_as_read_on_interaction">Mark posts as read on interaction</string>
+    <string name="settings_mark_as_read_on_interaction_subtitle">After voting or saving a post, mark it as read</string>
     <string name="settings_mark_as_read_while_scrolling">Mark posts as read while scrolling</string>
     <string name="settings_media_list">Media uploads</string>
     <string name="settings_navigation_bar_titles_visible">Show navigation bar titles</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/resources/SharedStrings.kt
@@ -437,6 +437,8 @@ import raccoonforlemmy.shared.generated.resources.settings_manage_ban_section_do
 import raccoonforlemmy.shared.generated.resources.settings_manage_ban_section_instances
 import raccoonforlemmy.shared.generated.resources.settings_manage_ban_section_stop_words
 import raccoonforlemmy.shared.generated.resources.settings_manage_ban_stop_word_placeholder
+import raccoonforlemmy.shared.generated.resources.settings_mark_as_read_on_interaction
+import raccoonforlemmy.shared.generated.resources.settings_mark_as_read_on_interaction_subtitle
 import raccoonforlemmy.shared.generated.resources.settings_mark_as_read_while_scrolling
 import raccoonforlemmy.shared.generated.resources.settings_media_list
 import raccoonforlemmy.shared.generated.resources.settings_navigation_bar_titles_visible
@@ -1383,6 +1385,10 @@ internal class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.settings_manage_ban_section_stop_words)
     override val settingsManageBanStopWordPlaceholder: String
         @Composable get() = stringResource(Res.string.settings_manage_ban_stop_word_placeholder)
+    override val settingsMarkAsReadOnInteraction: String
+        @Composable get() = stringResource(Res.string.settings_mark_as_read_on_interaction)
+    override val settingsMarkAsReadOnInteractionSubtitle: String
+        @Composable get() = stringResource(Res.string.settings_mark_as_read_on_interaction_subtitle)
     override val settingsMarkAsReadWhileScrolling: String
         @Composable get() = stringResource(Res.string.settings_mark_as_read_while_scrolling)
     override val settingsMediaList: String

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -542,6 +542,7 @@ class CommunityDetailViewModel(
                 post = post,
                 voted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -551,7 +552,11 @@ class CommunityDetailViewModel(
                     post = post,
                     voted = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
                 notificationCenter.send(
                     event = NotificationCenterEvent.PostUpdated(newPost),
                 )
@@ -588,6 +593,7 @@ class CommunityDetailViewModel(
                 post = post,
                 downVoted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -597,7 +603,11 @@ class CommunityDetailViewModel(
                     post = post,
                     downVoted = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
                 notificationCenter.send(
                     event = NotificationCenterEvent.PostUpdated(newPost),
                 )
@@ -615,6 +625,7 @@ class CommunityDetailViewModel(
                 post = post,
                 saved = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -624,7 +635,11 @@ class CommunityDetailViewModel(
                     post = post,
                     saved = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
                 notificationCenter.send(
                     event = NotificationCenterEvent.PostUpdated(newPost),
                 )

--- a/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsViewModel.kt
+++ b/unit/mentions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/mentions/InboxMentionsViewModel.kt
@@ -255,6 +255,7 @@ class InboxMentionsViewModel(
                 mention = mention,
                 voted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handleItemUpdate(newMention)
         screenModelScope.launch {
             try {
@@ -264,7 +265,7 @@ class InboxMentionsViewModel(
                     comment = mention.comment,
                     voted = newValue,
                 )
-                if (!mention.read) {
+                if (!mention.read && shouldBeMarkedAsRead) {
                     userRepository.setMentionRead(
                         read = true,
                         mentionId = mention.id,
@@ -286,6 +287,7 @@ class InboxMentionsViewModel(
                 mention = mention,
                 downVoted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handleItemUpdate(newMention)
         screenModelScope.launch {
             try {
@@ -295,7 +297,7 @@ class InboxMentionsViewModel(
                     comment = mention.comment,
                     downVoted = newValue,
                 )
-                if (!mention.read) {
+                if (!mention.read && shouldBeMarkedAsRead) {
                     userRepository.setMentionRead(
                         read = true,
                         mentionId = mention.id,

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -304,6 +304,7 @@ class MultiCommunityViewModel(
                 post = post,
                 voted = newVote,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -313,7 +314,11 @@ class MultiCommunityViewModel(
                     auth = auth,
                     voted = newVote,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)
@@ -347,6 +352,7 @@ class MultiCommunityViewModel(
                 post = post,
                 downVoted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -356,7 +362,11 @@ class MultiCommunityViewModel(
                     auth = auth,
                     downVoted = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)
@@ -371,6 +381,7 @@ class MultiCommunityViewModel(
                 post = post,
                 saved = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -380,7 +391,11 @@ class MultiCommunityViewModel(
                     auth = auth,
                     saved = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
@@ -418,6 +418,7 @@ class PostListViewModel(
                 voted = newVote,
             )
         handlePostUpdate(newPost)
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         screenModelScope.launch {
             try {
                 val auth = identityRepository.authToken.value.orEmpty()
@@ -426,7 +427,11 @@ class PostListViewModel(
                     auth = auth,
                     voted = newVote,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)
@@ -460,6 +465,7 @@ class PostListViewModel(
                 post = post,
                 downVoted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -469,7 +475,11 @@ class PostListViewModel(
                     auth = auth,
                     downVoted = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)
@@ -484,6 +494,7 @@ class PostListViewModel(
                 post = post,
                 saved = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handlePostUpdate(newPost)
         screenModelScope.launch {
             try {
@@ -493,7 +504,11 @@ class PostListViewModel(
                     auth = auth,
                     saved = newValue,
                 )
-                markAsRead(newPost)
+                if (shouldBeMarkedAsRead) {
+                    markAsRead(newPost)
+                } else {
+                    handlePostUpdate(newPost)
+                }
             } catch (e: Throwable) {
                 e.printStackTrace()
                 handlePostUpdate(post)

--- a/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
+++ b/unit/replies/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/replies/InboxRepliesViewModel.kt
@@ -252,6 +252,7 @@ class InboxRepliesViewModel(
                 mention = mention,
                 voted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handleItemUpdate(newMention)
         screenModelScope.launch {
             try {
@@ -261,7 +262,7 @@ class InboxRepliesViewModel(
                     comment = mention.comment,
                     voted = newValue,
                 )
-                if (!mention.read) {
+                if (!mention.read && shouldBeMarkedAsRead) {
                     userRepository.setReplyRead(
                         read = true,
                         replyId = mention.id,
@@ -283,6 +284,7 @@ class InboxRepliesViewModel(
                 mention = mention,
                 downVoted = newValue,
             )
+        val shouldBeMarkedAsRead = settingsRepository.currentSettings.value.markAsReadOnInteraction
         handleItemUpdate(newMention)
         screenModelScope.launch {
             try {
@@ -292,7 +294,7 @@ class InboxRepliesViewModel(
                     comment = mention.comment,
                     downVoted = newValue,
                 )
-                if (!mention.read) {
+                if (!mention.read && shouldBeMarkedAsRead) {
                     userRepository.setReplyRead(
                         read = true,
                         replyId = mention.id,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds the possibility to disable the default behaviour which marks posts as read even after they are saved or voted.
