### PR TITLE
fix: remove custom WindowInsets from Scaffolds

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.feature.inbox.main
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -93,7 +92,6 @@ object InboxScreen : Tab {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.feature.profile.main
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -164,7 +163,6 @@ internal object ProfileMainScreen : Tab {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -129,7 +128,6 @@ class AdvancedSettingsScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
                     .onGloballyPositioned {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -131,7 +130,6 @@ class SettingsColorAndFontScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.feature.settings.main
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -111,7 +110,6 @@ class SettingsScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/main/MainScreen.kt
@@ -188,7 +188,6 @@ internal object MainScreen : Screen {
             }
 
             Scaffold(
-                contentWindowInsets = WindowInsets(0, 0, 0, 0),
                 snackbarHost = {
                     SnackbarHost(snackbarHostState) { data ->
                         Snackbar(

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -153,7 +152,6 @@ class AccountSettingsScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
+++ b/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.acknowledgements.main
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -51,7 +50,6 @@ class AcknowledgementsScreen : Screen {
         val uriHandler = LocalUriHandler.current
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
+++ b/unit/chat/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/chat/InboxChatScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -123,7 +122,6 @@ class InboxChatScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier = Modifier.navigationBarsPadding().safeImePadding(),
             topBar = {
                 TopAppBar(

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -262,7 +261,6 @@ class CommunityDetailScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.configurecontentview
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -77,7 +76,6 @@ class ConfigureContentViewScreen : Screen {
         var selectPostBodyMaxLinesBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
+++ b/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -96,7 +95,6 @@ class ConfigureNavBarScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -83,7 +82,6 @@ class ConfigureSwipeActionsScreen : Screen {
         var selectActionBottomSheet by remember { mutableStateOf<ActionConfig?>(null) }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,
@@ -180,7 +178,7 @@ class ConfigureSwipeActionsScreen : Screen {
                                     1 -> LocalStrings.current.swipeActionStartTwo
                                     else -> LocalStrings.current.swipeActionStartOne
                                 },
-                                action = action,
+                            action = action,
                             options =
                                 buildList {
                                     this +=
@@ -243,8 +241,8 @@ class ConfigureSwipeActionsScreen : Screen {
                                 when (idx) {
                                     1 -> LocalStrings.current.swipeActionEndTwo
                                     else -> LocalStrings.current.swipeActionEndOne
-                            },
-                                action = action,
+                                },
+                            action = action,
                             options =
                                 buildList {
                                     this +=
@@ -335,8 +333,8 @@ class ConfigureSwipeActionsScreen : Screen {
                                 when (idx) {
                                     1 -> LocalStrings.current.swipeActionStartTwo
                                     else -> LocalStrings.current.swipeActionStartOne
-                            },
-                                action = action,
+                                },
+                            action = action,
                             options =
                                 buildList {
                                     this +=
@@ -398,9 +396,9 @@ class ConfigureSwipeActionsScreen : Screen {
                             iconContentDescription =
                                 when (idx) {
                                     1 -> LocalStrings.current.swipeActionEndTwo
-                                else -> LocalStrings.current.swipeActionEndOne
-                            },
-                                action = action,
+                                    else -> LocalStrings.current.swipeActionEndOne
+                                },
+                            action = action,
                             options =
                                 buildList {
                                     this +=
@@ -490,9 +488,9 @@ class ConfigureSwipeActionsScreen : Screen {
                             iconContentDescription =
                                 when (idx) {
                                     1 -> LocalStrings.current.swipeActionStartTwo
-                                else -> LocalStrings.current.swipeActionStartOne
-                            },
-                                action = action,
+                                    else -> LocalStrings.current.swipeActionStartOne
+                                },
+                            action = action,
                             options =
                                 buildList {
                                     this +=
@@ -553,10 +551,10 @@ class ConfigureSwipeActionsScreen : Screen {
                                 },
                             iconContentDescription =
                                 when (idx) {
-                                1 -> LocalStrings.current.swipeActionEndTwo
-                                else -> LocalStrings.current.swipeActionEndOne
-                            },
-                                action = action,
+                                    1 -> LocalStrings.current.swipeActionEndTwo
+                                    else -> LocalStrings.current.swipeActionEndOne
+                                },
+                            action = action,
                             options =
                                 buildList {
                                     this +=

--- a/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
+++ b/unit/createcomment/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createcomment/CreateCommentScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -158,7 +157,6 @@ class CreateCommentScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
                     .navigationBarsPadding()

--- a/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
+++ b/unit/createpost/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/createpost/CreatePostScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -244,7 +243,6 @@ class CreatePostScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
                     .navigationBarsPadding()

--- a/unit/drafts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drafts/DraftsScreen.kt
+++ b/unit/drafts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/drafts/DraftsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -71,7 +70,6 @@ class DraftsScreen : Screen {
         var itemToDelete by remember { mutableStateOf<DraftModel?>(null) }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -140,7 +139,6 @@ class EditCommunityScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -192,7 +191,6 @@ class ExploreScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 ExploreTopBar(
                     topAppBarState = topAppBarState,

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -174,7 +174,6 @@ class FilteredContentsScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),

--- a/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.instanceinfo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -89,7 +88,6 @@ class InstanceInfoScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.licences
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -47,7 +46,6 @@ class LicencesScreen : Screen {
         val uriHandler = LocalUriHandler.current
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
+++ b/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -125,7 +124,6 @@ class ManageBanScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/medialist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/medialist/MediaListScreen.kt
+++ b/unit/medialist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/medialist/MediaListScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.medialist
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -85,7 +84,6 @@ class MediaListScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     title = {

--- a/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
+++ b/unit/modlog/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/modlog/ModlogScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforlemmy.unit.modlog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -92,7 +91,6 @@ class ModlogScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -146,7 +145,6 @@ class MultiCommunityScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 val sortType = uiState.sortType
                 TopAppBar(

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -273,7 +273,6 @@ class PostDetailScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     windowInsets = topAppBarState.toWindowInsets(),
@@ -1069,7 +1068,8 @@ class PostDetailScreen(
                                                             updateDate ?: publishDate
                                                         }?.toTimestamp()
                                                     val lastSeenTs = uiState.lastSeenTimestamp
-                                                    val isAfterLastSeenTs =   commentTs != null &&
+                                                    val isAfterLastSeenTs =
+                                                        commentTs != null &&
                                                             lastSeenTs != null &&
                                                             commentTs > lastSeenTs
                                                     val backgroundModifier =

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -203,7 +203,6 @@ class PostListScreen : Screen {
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 PostsTopBar(
                     currentInstance = uiState.instance,

--- a/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
+++ b/unit/reportlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/reportlist/ReportListScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -109,7 +108,6 @@ class ReportListScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
                     scrollBehavior = scrollBehavior,

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -216,7 +215,6 @@ class UserDetailScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 val userName = uiState.user.readableName(uiState.preferNicknames)
                 TopAppBar(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes custom WindowInsets from Scaffold contents because it is no longer needed with edge to edge enabled and it, actually, could lead to more harm than good.
