### PR TITLE
enhancement: add workaround for solid status bar color

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -94,9 +94,11 @@ dependencies {
     implementation(libs.voyager.tab)
 
     implementation(projects.shared)
+    implementation(projects.core.appearance)
     implementation(projects.core.di)
     implementation(projects.core.utils)
     implementation(projects.core.navigation)
+    implementation(projects.core.persistence)
     implementation(projects.core.resources)
 
     kover(projects.shared)

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/SolidBarColorWorkaround.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/SolidBarColorWorkaround.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforlemmy.core.appearance.theme
+
+import android.app.Activity
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiBarTheme
+import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiTheme
+
+interface SolidBarColorWorkaround {
+    fun apply(
+        activity: Activity,
+        theme: UiTheme,
+        barTheme: UiBarTheme,
+    )
+}

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/BarColorProvider.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/BarColorProvider.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.UiTheme
 
 interface BarColorProvider {
     val isBarThemeSupported: Boolean
+    val isOpaqueThemeSupported: Boolean
 
     @Composable
     fun setBarColorAccordingToTheme(

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -11,6 +11,7 @@ import platform.UIKit.setStatusBarStyle
 
 internal class DefaultBarColorProvider : BarColorProvider {
     override val isBarThemeSupported = false
+    override val isOpaqueThemeSupported = false
 
     @Composable
     override fun setBarColorAccordingToTheme(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsMviModel.kt
@@ -131,6 +131,7 @@ interface AdvancedSettingsMviModel :
         val enableAlternateMarkdownRendering: Boolean = false,
         val restrictLocalUserSearch: Boolean = false,
         val isBarThemeSupported: Boolean = false,
+        val isBarOpaqueThemeSupported: Boolean = false,
         val markAsReadOnInteraction: Boolean = true,
     )
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -665,11 +665,13 @@ class AdvancedSettingsScreen : Screen {
 
         if (barThemeBottomSheetOpened) {
             val values =
-                listOf(
-                    UiBarTheme.Transparent,
-                    UiBarTheme.Opaque,
-                    UiBarTheme.Solid,
-                )
+                buildList {
+                    this += UiBarTheme.Transparent
+                    if (uiState.isBarOpaqueThemeSupported) {
+                        this += UiBarTheme.Opaque
+                    }
+                    this += UiBarTheme.Solid
+                }
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsBarTheme,
                 items =

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsViewModel.kt
@@ -167,6 +167,7 @@ class AdvancedSettingsViewModel(
                     enableAlternateMarkdownRendering = settings.enableAlternateMarkdownRendering,
                     restrictLocalUserSearch = settings.restrictLocalUserSearch,
                     isBarThemeSupported = barColorProvider.isBarThemeSupported,
+                    isBarOpaqueThemeSupported = barColorProvider.isOpaqueThemeSupported,
                     markAsReadOnInteraction = settings.markAsReadOnInteraction,
                 )
             }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR makes it possible, if one really wants to, set the "Solid" status bar theme even on Android >= 15.

## Additional notes
<!-- Anything to declare for code review? -->
This is tricky, because the `setOnApplyWindowInsetsListener` should be done in the right moment in the Activity lifecycle otherwise it is never called.

Moreover, it introduces a slight startup overhead because settings have to be read in order to determine the current UI theme and bar theme.
