### PR TITLE
fix: improve image download and share

### DIFF
--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/notifications/NotificationCenterEvent.kt
@@ -197,17 +197,6 @@ sealed interface NotificationCenterEvent {
         val value: CommunityModel,
     ) : NotificationCenterEvent
 
-    sealed interface ShareImageModeSelected : NotificationCenterEvent {
-        data class ModeUrl(
-            val url: String,
-        ) : ShareImageModeSelected
-
-        data class ModeFile(
-            val url: String,
-            val source: String,
-        ) : ShareImageModeSelected
-    }
-
     data class AppIconVariantSelected(
         val value: Int,
     ) : NotificationCenterEvent

--- a/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageMviModel.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageMviModel.kt
@@ -14,7 +14,20 @@ interface ZoomableImageMviModel :
             val source: String,
         ) : Intent
 
-        data class ChangeContentScale(val contentScale: ContentScale) : Intent
+        sealed interface ShareImageModeSelected : Intent {
+            data class ModeUrl(
+                val url: String,
+            ) : ShareImageModeSelected
+
+            data class ModeFile(
+                val url: String,
+                val source: String,
+            ) : ShareImageModeSelected
+        }
+
+        data class ChangeContentScale(
+            val contentScale: ContentScale,
+        ) : Intent
     }
 
     data class UiState(

--- a/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/ZoomableImageScreen.kt
@@ -47,8 +47,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBot
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
 import kotlinx.coroutines.flow.launchIn
@@ -70,7 +68,6 @@ class ZoomableImageScreen(
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val drawerCoordinator = remember { getDrawerCoordinator() }
         val shareHelper = remember { getShareHelper() }
-        val notificationCenter = remember { getNotificationCenter() }
         var imageShareBottomSheetOpened by remember { mutableStateOf(false) }
 
         LaunchedEffect(model) {
@@ -123,8 +120,10 @@ class ZoomableImageScreen(
                                 if (shareHelper.supportsShareImage) {
                                     imageShareBottomSheetOpened = true
                                 } else {
-                                    notificationCenter.send(
-                                        NotificationCenterEvent.ShareImageModeSelected.ModeUrl(url),
+                                    model.reduce(
+                                        ZoomableImageMviModel.Intent.ShareImageModeSelected.ModeUrl(
+                                            url,
+                                        ),
                                     )
                                 }
                             },
@@ -253,12 +252,14 @@ class ZoomableImageScreen(
                     imageShareBottomSheetOpened = false
                     if (index != null) {
                         if (index == 0) {
-                            notificationCenter.send(
-                                NotificationCenterEvent.ShareImageModeSelected.ModeUrl(url),
+                            model.reduce(
+                                ZoomableImageMviModel.Intent.ShareImageModeSelected.ModeUrl(
+                                    url,
+                                ),
                             )
                         } else {
-                            notificationCenter.send(
-                                NotificationCenterEvent.ShareImageModeSelected.ModeFile(
+                            model.reduce(
+                                ZoomableImageMviModel.Intent.ShareImageModeSelected.ModeFile(
                                     url = url,
                                     source = source,
                                 ),

--- a/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/di/ZoomableImageModule.kt
+++ b/unit/zoomableimage/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/zoomableimage/di/ZoomableImageModule.kt
@@ -16,9 +16,8 @@ val zoomableImageModule =
                     settingsRepository = instance(),
                     shareHelper = instance(),
                     galleryHelper = instance(),
-                    notificationCenter = instance(),
                     imagePreloadManager = instance(),
-            )
+                )
+            }
         }
     }
-}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR improves the mechanism to download and save/share image files used in the app. It involves:
- removing notification dispatching for this kind of events, which is not needed any more because they can be converted to simple MVI intents;
- preventing duplicated even processing by reading the `loading` status before processing them;
- factor out shared code and other minor refactoring interventions.
