### PR TITLE
fix: comment sort type

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/dto/CommentSortType.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/dto/CommentSortType.kt
@@ -14,4 +14,7 @@ enum class CommentSortType {
 
     @SerialName("Old")
     Old,
+
+    @SerialName("Controversial")
+    Controversial,
 }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
@@ -148,6 +148,7 @@ internal fun SortType.toCommentDto(): CommentSortType =
         SortType.New -> CommentSortType.New
         SortType.Top.Generic -> CommentSortType.Top
         SortType.Old -> CommentSortType.Old
+        SortType.Controversial -> CommentSortType.Controversial
         else -> CommentSortType.New
     }
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -516,7 +516,7 @@ class SettingsScreen : Screen {
         if (sortCommentsBottomSheetOpened) {
             SortBottomSheet(
                 values = uiState.availableSortTypesForComments,
-                expandTop = true,
+                expandTop = false,
                 onSelected = { value ->
                     sortCommentsBottomSheetOpened = false
                     if (value != null) {

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailMviModel.kt
@@ -121,7 +121,7 @@ interface PostDetailMviModel :
         val loading: Boolean = false,
         val initial: Boolean = true,
         val canFetchMore: Boolean = true,
-        val sortType: SortType = SortType.New,
+        val sortType: SortType? = null,
         val comments: List<CommentModel> = emptyList(),
         val commentBarThickness: Int = 1,
         val commentIndentAmount: Int = 2,

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -287,15 +287,17 @@ class PostDetailScreen(
                         )
                     },
                     actions = {
-                        IconButton(
-                            onClick = {
-                                sortBottomSheetOpened = true
-                            },
-                        ) {
-                            Icon(
-                                imageVector = uiState.sortType.toIcon(),
-                                contentDescription = uiState.sortType.toReadableName(),
-                            )
+                        uiState.sortType?.also { sortType ->
+                            IconButton(
+                                onClick = {
+                                    sortBottomSheetOpened = true
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = sortType.toIcon(),
+                                    contentDescription = sortType.toReadableName(),
+                                )
+                            }
                         }
 
                         // options menu

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -486,10 +486,13 @@ class PostDetailViewModel(
     }
 
     private suspend fun refresh(initial: Boolean = false) {
+        val currentState = uiState.value
+        val sortType = currentState.sortType ?: return
+        val postId = currentState.post.id
         commentPaginationManager.reset(
             CommentPaginationSpecification.Replies(
-                postId = uiState.value.post.id,
-                sortType = uiState.value.sortType,
+                postId = postId,
+                sortType = sortType,
                 otherInstance = otherInstance,
                 includeDeleted = true,
             ),
@@ -628,10 +631,10 @@ class PostDetailViewModel(
         parentId: Long,
         loadUntilHighlight: Boolean = false,
     ) {
+        val currentState = uiState.value
+        val sort = currentState.sortType ?: return
         screenModelScope.launch {
-            val currentState = uiState.value
             val auth = identityRepository.authToken.value
-            val sort = currentState.sortType
             val fetchResult =
                 commentRepository
                     .getChildren(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR solves several issues related to comment sort type selection:
- in the settings screen, the last option should not expand because the only available option for comments is `"Top"`
- `"Controversial"` sort type was not mapped, resulting in it being treated as "New" instead
- the post detail screen showed the default (`"New"`) type before loading it from settings, which is poor user experience.

The results which are coming from the server, especially if there are few comments, do not change but this is not an application bug.