### PR TITLE
enhancement: avoid expanding/collapsing comments on click outside the arrow button

### DIFF
--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -1129,13 +1129,6 @@ class PostDetailScreen(
                                                                 ),
                                                             )
                                                         },
-                                                        onClick = {
-                                                            model.reduce(
-                                                                PostDetailMviModel.Intent.ToggleExpandComment(
-                                                                    comment.id,
-                                                                ),
-                                                            )
-                                                        },
                                                         onDoubleClick =
                                                             {
                                                                 model.reduce(
@@ -1452,13 +1445,6 @@ class PostDetailScreen(
                                                 indentAmount = uiState.commentIndentAmount,
                                                 barThickness = uiState.commentBarThickness,
                                                 onToggleExpanded = {
-                                                    model.reduce(
-                                                        PostDetailMviModel.Intent.ToggleExpandComment(
-                                                            comment.id,
-                                                        ),
-                                                    )
-                                                },
-                                                onClick = {
                                                     model.reduce(
                                                         PostDetailMviModel.Intent.ToggleExpandComment(
                                                             comment.id,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR restores the default behaviour of comments: only the arrow button can be used to toggle expand/collapse whereas clicking on the whole comment doesn't do anything in post detail.