### PR TITLE
refactor: move domain Lemmy use cases to separate module

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     kover(projects.domain.inbox)
     kover(projects.domain.lemmy.repository)
     kover(projects.domain.lemmy.pagination)
+    kover(projects.domain.lemmy.usecase)
     kover(projects.feature.inbox)
     kover(projects.feature.profile)
 }

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultIsSiteVersionAtLeastUseCaseTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/DefaultIsSiteVersionAtLeastUseCaseTest.kt
@@ -20,11 +20,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenSameVersion_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.19.2"
+            coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(0, 19, 2)
+            val res = sut.execute(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }
@@ -32,11 +30,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenPatchLessThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.19.2"
+            coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(0, 19, 3)
+            val res = sut.execute(major = 0, minor = 19, patch = 3)
 
             assertFalse(res)
         }
@@ -44,11 +40,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenPatchGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.19.2"
+            coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(0, 19, 1)
+            val res = sut.execute(major = 0, minor = 19, patch = 1)
 
             assertTrue(res)
         }
@@ -56,11 +50,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenMinorLessThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.18.2"
+            coEvery { siteRepository.getSiteVersion() } returns "0.18.2"
 
-            val res = sut.execute(0, 19, 1)
+            val res = sut.execute(major = 0, minor = 19, patch = 2)
 
             assertFalse(res)
         }
@@ -68,11 +60,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenMinorGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.20.2"
+            coEvery { siteRepository.getSiteVersion() } returns "0.20.2"
 
-            val res = sut.execute(0, 19, 1)
+            val res = sut.execute(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }
@@ -80,11 +70,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenMajorLessThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "0.2.1"
+            coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(1, 1, 1)
+            val res = sut.execute(major = 1, minor = 0, patch = 0)
 
             assertFalse(res)
         }
@@ -92,11 +80,9 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     @Test
     fun givenMajorGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
         runTest {
-            coEvery {
-                siteRepository.getSiteVersion()
-            } returns "1.1.0"
+            coEvery { siteRepository.getSiteVersion() } returns "1.0.0"
 
-            val res = sut.execute(0, 19, 1)
+            val res = sut.execute(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/di/LemmyRepositoryModule.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/di/LemmyRepositoryModule.kt
@@ -8,10 +8,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepo
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultCommentRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultCommunityRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultGetSiteSupportsHiddenPostsUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultGetSiteSupportsMediaListUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultGetSortTypesUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultIsSiteVersionAtLeastUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultLemmyItemCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultLemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultLocalItemCache
@@ -22,10 +18,6 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultPriv
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultSiteRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultUserRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.DefaultUserTagHelper
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsHiddenPostsUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsMediaListUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.IsSiteVersionAtLeastUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyItemCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LocalItemCache
@@ -74,34 +66,6 @@ val lemmyRepositoryModule =
                 DefaultCommunityRepository(
                     services = instance(tag = "default"),
                     customServices = instance(tag = "custom"),
-                )
-            }
-        }
-        bind<GetSiteSupportsHiddenPostsUseCase> {
-            singleton {
-                DefaultGetSiteSupportsHiddenPostsUseCase(
-                    isSiteVersionAtLeastUseCase = instance(),
-                )
-            }
-        }
-        bind<GetSiteSupportsMediaListUseCase> {
-            singleton {
-                DefaultGetSiteSupportsMediaListUseCase(
-                    isSiteVersionAtLeastUseCase = instance(),
-                )
-            }
-        }
-        bind<GetSortTypesUseCase> {
-            singleton {
-                DefaultGetSortTypesUseCase(
-                    isSiteVersionAtLeastUseCase = instance(),
-                )
-            }
-        }
-        bind<IsSiteVersionAtLeastUseCase> {
-            singleton {
-                DefaultIsSiteVersionAtLeastUseCase(
-                    siteRepository = instance(),
                 )
             }
         }

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/Mappings.kt
@@ -616,7 +616,7 @@ internal fun LocalUserView.toModel() =
         avatar = person.avatar,
         banner = person.banner,
         bio = person.bio,
-        bot = person.botAccount ?: false,
+        bot = person.botAccount == true,
         displayName = person.displayName,
         matrixUserId = person.matrixUserId,
         showUpVotes = localUserVoteDisplayMode?.upvotes,

--- a/domain/lemmy/usecase/build.gradle.kts
+++ b/domain/lemmy/usecase/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.androidTest")
+    alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.kodein)
+
+                implementation(projects.domain.lemmy.data)
+                implementation(projects.domain.lemmy.repository)
+            }
+        }
+    }
+}

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import io.mockk.coEvery

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import io.mockk.coEvery

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCaseTest.kt
@@ -1,6 +1,7 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCase.kt
@@ -1,8 +1,8 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
-internal class DefaultGetSiteSupportsMediaListUseCase(
+internal class DefaultGetSiteSupportsHiddenPostsUseCase(
     private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase,
-) : GetSiteSupportsMediaListUseCase {
+) : GetSiteSupportsHiddenPostsUseCase {
     companion object {
         const val THRESHOLD_MAJOR = 0
         const val THRESHOLD_MINOR = 19

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCase.kt
@@ -1,8 +1,8 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
-internal class DefaultGetSiteSupportsHiddenPostsUseCase(
+internal class DefaultGetSiteSupportsMediaListUseCase(
     private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase,
-) : GetSiteSupportsHiddenPostsUseCase {
+) : GetSiteSupportsMediaListUseCase {
     companion object {
         const val THRESHOLD_MAJOR = 0
         const val THRESHOLD_MINOR = 19

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCase.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCase.kt
@@ -1,4 +1,6 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
+
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 
 internal class DefaultIsSiteVersionAtLeastUseCase(
     private val siteRepository: SiteRepository,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSiteSupportsHiddenPostsUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSiteSupportsHiddenPostsUseCase.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 interface GetSiteSupportsHiddenPostsUseCase {
     suspend operator fun invoke(): Boolean

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSiteSupportsMediaListUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSiteSupportsMediaListUseCase.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 interface GetSiteSupportsMediaListUseCase {
     suspend operator fun invoke(): Boolean

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSortTypesUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/GetSortTypesUseCase.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/IsSiteVersionAtLeastUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/IsSiteVersionAtLeastUseCase.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 interface IsSiteVersionAtLeastUseCase {
     suspend fun execute(

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/di/LemmyUseCaseModule.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/di/LemmyUseCaseModule.kt
@@ -1,0 +1,45 @@
+package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.di
+
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.DefaultGetSiteSupportsHiddenPostsUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.DefaultGetSiteSupportsMediaListUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.DefaultGetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.DefaultIsSiteVersionAtLeastUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSiteSupportsHiddenPostsUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSiteSupportsMediaListUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.IsSiteVersionAtLeastUseCase
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
+import org.kodein.di.singleton
+
+val lemmyUseCaseModule = DI.Module("LemmyUseCaseModule") {
+    bind<GetSiteSupportsHiddenPostsUseCase> {
+        singleton {
+            DefaultGetSiteSupportsHiddenPostsUseCase(
+                isSiteVersionAtLeastUseCase = instance(),
+            )
+        }
+    }
+    bind<GetSiteSupportsMediaListUseCase> {
+        singleton {
+            DefaultGetSiteSupportsMediaListUseCase(
+                isSiteVersionAtLeastUseCase = instance(),
+            )
+        }
+    }
+    bind<GetSortTypesUseCase> {
+        singleton {
+            DefaultGetSortTypesUseCase(
+                isSiteVersionAtLeastUseCase = instance(),
+            )
+        }
+    }
+    bind<IsSiteVersionAtLeastUseCase> {
+        singleton {
+            DefaultIsSiteVersionAtLeastUseCase(
+                siteRepository = instance(),
+            )
+        }
+    }
+}

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
 
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
                 implementation(projects.domain.identity)
 
                 implementation(projects.unit.web)

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsViewModel.kt
@@ -20,9 +20,9 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toInt
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toSortType
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsHiddenPostsUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSiteSupportsMediaListUseCase
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSiteSupportsHiddenPostsUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSiteSupportsMediaListUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,7 @@ include(":domain:inbox")
 include(":domain:lemmy:data")
 include(":domain:lemmy:pagination")
 include(":domain:lemmy:repository")
+include(":domain:lemmy:usecase")
 
 include(":feature:home")
 include(":feature:inbox")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.about)
                 implementation(projects.unit.accountsettings)

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/di/DiHelper.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/di/DiHelper.kt
@@ -14,6 +14,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.identity.di.identityModule
 import com.livefast.eattrash.raccoonforlemmy.domain.inbox.di.inboxModule
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.di.lemmyPaginationModule
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.di.lemmyRepositoryModule
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.di.lemmyUseCaseModule
 import com.livefast.eattrash.raccoonforlemmy.feature.inbox.di.inboxTabModule
 import com.livefast.eattrash.raccoonforlemmy.feature.profile.di.profileTabModule
 import com.livefast.eattrash.raccoonforlemmy.feature.settings.di.settingsTabModule
@@ -83,6 +84,7 @@ fun initDi(additionalBuilder: DI.Builder.() -> Unit = {}) {
                 inboxModule,
                 lemmyPaginationModule,
                 lemmyRepositoryModule,
+                lemmyUseCaseModule,
             )
 
             // features

--- a/unit/accountsettings/build.gradle.kts
+++ b/unit/accountsettings/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.domain.identity)
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
             }
         }
     }

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
@@ -10,7 +10,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.identity.usecase.LogoutUseCa
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.AccountSettingsModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.ListingType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.MediaRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserRepository

--- a/unit/communitydetail/build.gradle.kts
+++ b/unit/communitydetail/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.ban)
                 implementation(projects.unit.communityinfo)

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailViewModel.kt
@@ -32,7 +32,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostNavigat
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyItemCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository

--- a/unit/explore/build.gradle.kts
+++ b/unit/explore/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.createcomment)
                 implementation(projects.unit.moderatewithreason)

--- a/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreViewModel.kt
+++ b/unit/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/explore/ExploreViewModel.kt
@@ -28,7 +28,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.ExplorePagi
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.ExplorePaginationSpecification
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import kotlinx.coroutines.FlowPreview

--- a/unit/instanceinfo/build.gradle.kts
+++ b/unit/instanceinfo/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
             }
         }
     }

--- a/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoViewModel.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoViewModel.kt
@@ -8,7 +8,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Setting
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.CommunityPaginationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.CommunityPaginationSpecification
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/unit/multicommunity/build.gradle.kts
+++ b/unit/multicommunity/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.ban)
                 implementation(projects.unit.communityinfo)

--- a/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
+++ b/unit/multicommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/multicommunity/detail/MultiCommunityViewModel.kt
@@ -22,7 +22,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.toSortType
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository

--- a/unit/postdetail/build.gradle.kts
+++ b/unit/postdetail/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.ban)
                 implementation(projects.unit.createcomment)

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailViewModel.kt
@@ -25,7 +25,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.CommentPagi
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostNavigationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyItemCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository

--- a/unit/postlist/build.gradle.kts
+++ b/unit/postlist/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.ban)
                 implementation(projects.unit.communityinfo)

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListViewModel.kt
@@ -25,7 +25,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostNavigat
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommunityRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.SiteRepository

--- a/unit/userdetail/build.gradle.kts
+++ b/unit/userdetail/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.lemmy.data)
                 implementation(projects.domain.lemmy.pagination)
                 implementation(projects.domain.lemmy.repository)
+                implementation(projects.domain.lemmy.usecase)
 
                 implementation(projects.unit.ban)
                 implementation(projects.unit.chat)

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailViewModel.kt
@@ -31,7 +31,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostNavigat
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationManager
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.pagination.PostPaginationSpecification
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.CommentRepository
-import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.GetSortTypesUseCase
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase.GetSortTypesUseCase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyItemCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.PostRepository


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR moves all the use cases in `:domain:lemmy:repository` to a separate `:domain:lemmy:usecase` module. This is because more use cases will be added in the future to make it possible to retrieve data both on 0.9.x and 1.x.x back-end versions (e.g. retrieve the current user, etc.).

See task list in #349.
