### PR TITLE
chore: improve iOS support

### DIFF
--- a/androidApp/src/main/java/com/livefast/eattrash/raccoonforlemmy/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/livefast/eattrash/raccoonforlemmy/android/MainApplication.kt
@@ -6,17 +6,11 @@ import com.livefast.eattrash.raccoonforlemmy.core.di.RootDI
 import com.livefast.eattrash.raccoonforlemmy.core.utils.debug.CrashReportConfiguration
 import com.livefast.eattrash.raccoonforlemmy.core.utils.debug.CrashReportWriter
 import com.livefast.eattrash.raccoonforlemmy.di.initDi
-import org.kodein.di.DI
-import org.kodein.di.DIAware
 import org.kodein.di.bind
 import org.kodein.di.instance
 import org.kodein.di.provider
 
-class MainApplication :
-    Application(),
-    DIAware {
-    override val di: DI
-        get() = RootDI.di
+class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
@@ -28,6 +22,7 @@ class MainApplication :
     }
 
     private fun configureCrashReport() {
+        val di = RootDI.di
         val crashReportWriter: CrashReportWriter by di.instance()
         val crashReportConfig: CrashReportConfiguration by di.instance()
 

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 // workaround after KSP 2.0.0
 tasks.configureEach {
-    if (name.contains(Regex("ksp.*KotlinAndroid"))) {
+    if (name.contains(Regex("ksp.*KotlinAndroid")) || name.contains(Regex("ksp.*KotlinIos*"))) {
         dependsOn(tasks.named("kspCommonMainKotlinMetadata"))
     }
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import org.kodein.di.DI
+
+internal actual val nativeImageLoadModule = DI.Module("NativeImageLoadModule") {
+    // on Android nothing is needed
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import org.kodein.di.DI
+
+internal expect val nativeImageLoadModule: DI.Module

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeImageLoadModule.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import coil3.PlatformContext
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.singleton
+
+internal actual val nativeImageLoadModule = DI.Module("NativeImageLoadModule") {
+    bind<PlatformContext> {
+        singleton {
+            PlatformContext.INSTANCE
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 org.jetbrains.compose.experimental.uikit.enabled=true
 #Native
 kotlin.native.ignoreDisabledTargets=true
+kotlin.native.cacheKind=none

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ compose-colorpicker = { module = "com.github.skydoves:colorpicker-compose", vers
 gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 
 kodein = { module = "org.kodein.di:kodein-di", version.ref = "kodein" }
+kodein-compose = { module = "org.kodein.di:kodein-di-framework-compose", version.ref = "kodein" }
 
 kotlincrypto-bom = { module = "org.kotlincrypto.hash:bom", version.ref = "kotlincrypto" }
 kotlincrypto-md5 = { module = "org.kotlincrypto.hash:md" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
                 implementation(compose.components.resources)
 
                 implementation(libs.compose.multiplatform.media.player)
-                implementation(libs.kodein)
+                implementation(libs.kodein.compose)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/App.kt
@@ -43,6 +43,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.di.getThemeReposito
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.AppTheme
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.DraggableSideMenu
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.detailopener.api.getDetailOpener
+import com.livefast.eattrash.raccoonforlemmy.core.di.RootDI
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.ProvideStrings
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.di.getL10nManager
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.ComposeEvent
@@ -71,10 +72,11 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.kodein.di.compose.withDI
 
 @OptIn(FlowPreview::class)
 @Composable
-fun App(onLoadingFinished: () -> Unit = {}) {
+fun App(onLoadingFinished: () -> Unit = {}) = withDI(RootDI.di) {
     val accountRepository = remember { getAccountRepository() }
     val settingsRepository = remember { getSettingsRepository() }
     val appColorRepository = remember { getAppColorRepository() }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR prepares the ground for #408, making it possible to compile and launch the app (again) in iOS.

It was quite a long time I did not try to build it on iOS targets any more, and there were quite a few changes in the meantime:

- DI was migrated from Koin to Kodein
- image loading with Coil3 (instead of Kamel)
- KSP 2.0
- ...

so some adjustments were needed.

The app now builds and launches on an iOS simulator.
