### PR TITLE
refactor IsSiteVersionAtLeastUseCase

### DIFF
--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCaseTest.kt
@@ -13,18 +13,18 @@ class DefaultGetSiteSupportsHiddenPostsUseCaseTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase = mockk()
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase = mockk()
 
     private val sut =
         DefaultGetSiteSupportsHiddenPostsUseCase(
-            isSiteVersionAtLeastUseCase = isSiteVersionAtLeastUseCase,
+            isSiteVersionAtLeast = isSiteVersionAtLeast,
         )
 
     @Test
     fun givenVersionAboveThreshold_whenInvoke_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(
+                isSiteVersionAtLeast(
                     major = any(),
                     minor = any(),
                     patch = any(),
@@ -41,7 +41,7 @@ class DefaultGetSiteSupportsHiddenPostsUseCaseTest {
     fun givenVersionBelowThreshold_whenInvoke_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(
+                isSiteVersionAtLeast(
                     major = any(),
                     minor = any(),
                     patch = any(),

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCaseTest.kt
@@ -13,13 +13,20 @@ class DefaultGetSiteSupportsMediaListUseCaseTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val isSiteVersionAtLeastUseCase =
-        mockk<IsSiteVersionAtLeastUseCase> {
-            coEvery { execute(any(), any(), any(), any()) } returns true
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase =
+        mockk {
+            coEvery {
+                this@mockk.invoke(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
+            } returns true
         }
     private val sut =
         DefaultGetSiteSupportsMediaListUseCase(
-            isSiteVersionAtLeastUseCase = isSiteVersionAtLeastUseCase,
+            isSiteVersionAtLeast = isSiteVersionAtLeast,
         )
 
     @Test
@@ -29,7 +36,7 @@ class DefaultGetSiteSupportsMediaListUseCaseTest {
 
             assertTrue(res)
             coVerify {
-                isSiteVersionAtLeastUseCase.execute(major = 0, minor = 19, patch = 4)
+                isSiteVersionAtLeast(major = 0, minor = 19, patch = 4)
             }
         }
 }

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCaseTest.kt
@@ -14,18 +14,23 @@ class DefaultGetSortTypesUseCaseTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase = mockk()
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase = mockk()
 
     private val sut =
         DefaultGetSortTypesUseCase(
-            isSiteVersionAtLeastUseCase = isSiteVersionAtLeastUseCase,
+            isSiteVersionAtLeast = isSiteVersionAtLeast,
         )
 
     @Test
     fun givenVersionEqualToThreshold_whenGetTypesForPosts_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(any(), any(), any(), any())
+                isSiteVersionAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
             } returns true
 
             val res = sut.getTypesForPosts()
@@ -45,7 +50,12 @@ class DefaultGetSortTypesUseCaseTest {
     fun givenVersionGreaterThanThreshold_whenGetTypesForPosts_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(any(), any(), any(), any())
+                isSiteVersionAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
             } returns true
 
             val res = sut.getTypesForPosts()
@@ -65,7 +75,12 @@ class DefaultGetSortTypesUseCaseTest {
     fun givenVersionLessThanThreshold_whenGetTypesForPosts_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(any(), any(), any(), any())
+                isSiteVersionAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
             } returns false
 
             val res = sut.getTypesForPosts()
@@ -85,7 +100,12 @@ class DefaultGetSortTypesUseCaseTest {
     fun givenVersionGreaterThanThreshold_whenGetTypesForComments_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(any(), any(), any(), any())
+                isSiteVersionAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
             } returns true
 
             val res = sut.getTypesForComments()
@@ -101,7 +121,12 @@ class DefaultGetSortTypesUseCaseTest {
     fun givenVersionLessThanThreshold_whenGetTypesForComments_thenResultsIsAsExpected() =
         runTest {
             coEvery {
-                isSiteVersionAtLeastUseCase.execute(any(), any(), any(), any())
+                isSiteVersionAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
             } returns false
 
             val res = sut.getTypesForComments()

--- a/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCaseTest.kt
+++ b/domain/lemmy/usecase/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCaseTest.kt
@@ -19,71 +19,71 @@ class DefaultIsSiteVersionAtLeastUseCaseTest {
     private val sut = DefaultIsSiteVersionAtLeastUseCase(siteRepository = siteRepository)
 
     @Test
-    fun givenSameVersion_whenExecute_thenResultIsAsExpected() =
+    fun givenSameVersion_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 2)
+            val res = sut(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }
 
     @Test
-    fun givenPatchLessThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenPatchLessThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 3)
+            val res = sut(major = 0, minor = 19, patch = 3)
 
             assertFalse(res)
         }
 
     @Test
-    fun givenPatchGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenPatchGreaterThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 1)
+            val res = sut(major = 0, minor = 19, patch = 1)
 
             assertTrue(res)
         }
 
     @Test
-    fun givenMinorLessThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenMinorLessThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.18.2"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 2)
+            val res = sut(major = 0, minor = 19, patch = 2)
 
             assertFalse(res)
         }
 
     @Test
-    fun givenMinorGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenMinorGreaterThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.20.2"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 2)
+            val res = sut(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }
 
     @Test
-    fun givenMajorLessThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenMajorLessThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "0.19.2"
 
-            val res = sut.execute(major = 1, minor = 0, patch = 0)
+            val res = sut(major = 1, minor = 0, patch = 0)
 
             assertFalse(res)
         }
 
     @Test
-    fun givenMajorGreaterThanThreshold_whenExecute_thenResultIsAsExpected() =
+    fun givenMajorGreaterThanThreshold_whenInvoke_thenResultIsAsExpected() =
         runTest {
             coEvery { siteRepository.getSiteVersion() } returns "1.0.0"
 
-            val res = sut.execute(major = 0, minor = 19, patch = 2)
+            val res = sut(major = 0, minor = 19, patch = 2)
 
             assertTrue(res)
         }

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsHiddenPostsUseCase.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 internal class DefaultGetSiteSupportsHiddenPostsUseCase(
-    private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase,
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase,
 ) : GetSiteSupportsHiddenPostsUseCase {
     companion object {
         const val THRESHOLD_MAJOR = 0
@@ -10,7 +10,7 @@ internal class DefaultGetSiteSupportsHiddenPostsUseCase(
     }
 
     override suspend fun invoke(): Boolean =
-        isSiteVersionAtLeastUseCase.execute(
+        isSiteVersionAtLeast(
             major = THRESHOLD_MAJOR,
             minor = THRESHOLD_MINOR,
             patch = THRESHOLD_PATCH,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSiteSupportsMediaListUseCase.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 internal class DefaultGetSiteSupportsMediaListUseCase(
-    private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase,
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase,
 ) : GetSiteSupportsMediaListUseCase {
     companion object {
         const val THRESHOLD_MAJOR = 0
@@ -10,7 +10,7 @@ internal class DefaultGetSiteSupportsMediaListUseCase(
     }
 
     override suspend fun invoke(): Boolean =
-        isSiteVersionAtLeastUseCase.execute(
+        isSiteVersionAtLeast(
             major = THRESHOLD_MAJOR,
             minor = THRESHOLD_MINOR,
             patch = THRESHOLD_PATCH,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultGetSortTypesUseCase.kt
@@ -3,7 +3,7 @@ package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.SortType
 
 internal class DefaultGetSortTypesUseCase(
-    private val isSiteVersionAtLeastUseCase: IsSiteVersionAtLeastUseCase,
+    private val isSiteVersionAtLeast: IsSiteVersionAtLeastUseCase,
 ) : GetSortTypesUseCase {
     companion object {
         private const val THRESHOLD_MAJOR = 0
@@ -13,7 +13,7 @@ internal class DefaultGetSortTypesUseCase(
     override suspend fun getTypesForPosts(otherInstance: String?): List<SortType> =
         buildList {
             val isAtLeastThreshold =
-                isSiteVersionAtLeastUseCase.execute(
+                isSiteVersionAtLeast(
                     major = THRESHOLD_MAJOR,
                     minor = THRESHOLD_MINOR,
                     otherInstance = otherInstance,
@@ -34,7 +34,7 @@ internal class DefaultGetSortTypesUseCase(
     override suspend fun getTypesForComments(otherInstance: String?): List<SortType> =
         buildList {
             val isAtLeastThreshold =
-                isSiteVersionAtLeastUseCase.execute(
+                isSiteVersionAtLeast(
                     major = THRESHOLD_MAJOR,
                     minor = THRESHOLD_MINOR,
                     otherInstance = otherInstance,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/DefaultIsSiteVersionAtLeastUseCase.kt
@@ -9,7 +9,7 @@ internal class DefaultIsSiteVersionAtLeastUseCase(
         private val LEMMY_VERSION_REGEX = Regex("(?<major>\\d+).(?<minor>\\d+)(.(?<patch>\\d+))?")
     }
 
-    override suspend fun execute(
+    override suspend fun invoke(
         major: Int,
         minor: Int,
         patch: Int,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/IsSiteVersionAtLeastUseCase.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/IsSiteVersionAtLeastUseCase.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.lemmy.usecase
 
 interface IsSiteVersionAtLeastUseCase {
-    suspend fun execute(
+    suspend operator fun invoke(
         major: Int,
         minor: Int = 0,
         patch: Int = 0,

--- a/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/di/LemmyUseCaseModule.kt
+++ b/domain/lemmy/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/usecase/di/LemmyUseCaseModule.kt
@@ -13,31 +13,32 @@ import org.kodein.di.bind
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
-val lemmyUseCaseModule = DI.Module("LemmyUseCaseModule") {
-    bind<GetSiteSupportsHiddenPostsUseCase> {
-        singleton {
-            DefaultGetSiteSupportsHiddenPostsUseCase(
-                isSiteVersionAtLeastUseCase = instance(),
-            )
+val lemmyUseCaseModule =
+    DI.Module("LemmyUseCaseModule") {
+        bind<GetSiteSupportsHiddenPostsUseCase> {
+            singleton {
+                DefaultGetSiteSupportsHiddenPostsUseCase(
+                    isSiteVersionAtLeast = instance(),
+                )
+            }
         }
-    }
-    bind<GetSiteSupportsMediaListUseCase> {
-        singleton {
-            DefaultGetSiteSupportsMediaListUseCase(
-                isSiteVersionAtLeastUseCase = instance(),
-            )
+        bind<GetSiteSupportsMediaListUseCase> {
+            singleton {
+                DefaultGetSiteSupportsMediaListUseCase(
+                    isSiteVersionAtLeast = instance(),
+                )
+            }
         }
-    }
-    bind<GetSortTypesUseCase> {
-        singleton {
-            DefaultGetSortTypesUseCase(
-                isSiteVersionAtLeastUseCase = instance(),
-            )
+        bind<GetSortTypesUseCase> {
+            singleton {
+                DefaultGetSortTypesUseCase(
+                    isSiteVersionAtLeast = instance(),
+                )
+            }
         }
-    }
-    bind<IsSiteVersionAtLeastUseCase> {
-        singleton {
-            DefaultIsSiteVersionAtLeastUseCase(
+        bind<IsSiteVersionAtLeastUseCase> {
+            singleton {
+                DefaultIsSiteVersionAtLeastUseCase(
                 siteRepository = instance(),
             )
         }


### PR DESCRIPTION
overload invoke operator

## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR refactors `IsVersionAtLeastUseCase` to make it callable (like other use cases in the same package) with the invoke operator.

This is a follow-up on #409 to make it simpler to determine the backend version.