### PR TITLE
feat(api): new get remote account V4

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.service.v3.createSearchSer
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.v3.createSiteServiceV3
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.v3.createUserServiceV3
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.V4
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.createAccountServiceV4
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.createSiteServiceV4
 import com.livefast.eattrash.raccoonforlemmy.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.network.provideHttpClientEngineFactory
@@ -102,6 +103,7 @@ internal class DefaultServiceProvider(
             }
         v4 =
             object : V4 {
+                override val account = ktorfit.createAccountServiceV4()
                 override val site = ktorfit.createSiteServiceV4()
             }
     }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/AccountServiceV4.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/AccountServiceV4.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforlemmy.core.api.service.v4
+
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.MyUserInfo
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Header
+
+interface AccountServiceV4 {
+    @GET("v4/account")
+    suspend fun get(
+        @Header("Authorization") authHeader: String? = null,
+    ): MyUserInfo
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/V4.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/V4.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforlemmy.core.api.service.v4
 
 interface V4 {
+    val account: AccountServiceV4
     val site: SiteServiceV4
 }

--- a/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/DefaultSiteVersionDataSourceTest.kt
+++ b/domain/lemmy/repository/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/DefaultSiteVersionDataSourceTest.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import io.mockk.Called
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -16,7 +17,10 @@ class DefaultSiteVersionDataSourceTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
-    private val services = mockk<ServiceProvider>()
+    private val services =
+        mockk<ServiceProvider> {
+            every { currentInstance } returns "feddit.it"
+        }
     private val customServices = mockk<ServiceProvider>()
 
     private val sut =

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/SiteVersionDataSource.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/SiteVersionDataSource.kt
@@ -7,6 +7,12 @@ interface SiteVersionDataSource {
         patch: Int = 0,
         otherInstance: String? = null,
     ): Boolean
-
-    suspend fun shouldUseV4(otherInstance: String? = null): Boolean
 }
+
+internal suspend fun SiteVersionDataSource.shouldUseV4(otherInstance: String? = null): Boolean =
+    isAtLeast(
+        otherInstance = otherInstance,
+        major = 1,
+        minor = 0,
+        patch = 0,
+    )


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->

This PR  makes it possible to retrieve the current user :
- on Lemmy < 1.0.0 using the GET `v3/site` endpoint (by the `my_user` property in the response)
- on Lemmy >= 1.0.0 using the GET `v4/account` endpoint.

This is the real beginning of the service migration for the new backend version 🎉 (see #349).