### PR TITLE
feat(api): add support for V4 login and logout methods

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v3/AuthServiceV3.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v3/AuthServiceV3.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforlemmy.core.api.service.v3
 
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginResponse
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SuccessResponse
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
@@ -12,4 +13,7 @@ interface AuthServiceV3 {
     suspend fun login(
         @Body form: LoginForm,
     ): LoginResponse
+
+    @POST("v3/user/logout")
+    suspend fun logout(): SuccessResponse
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/AccountServiceV4.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/service/v4/AccountServiceV4.kt
@@ -1,12 +1,27 @@
 package com.livefast.eattrash.raccoonforlemmy.core.api.service.v4
 
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginForm
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.MyUserInfo
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SuccessResponse
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Header
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
 
 interface AccountServiceV4 {
     @GET("v4/account")
     suspend fun get(
         @Header("Authorization") authHeader: String? = null,
     ): MyUserInfo
+
+    @POST("v4/account/auth/login")
+    @Headers("Content-Type: application/json")
+    suspend fun login(
+        @Body form: LoginForm,
+    ): LoginResponse
+
+    @GET("v4/account/auth/logout")
+    suspend fun logout(): SuccessResponse
 }

--- a/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultAuthRepositoryTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultAuthRepositoryTest.kt
@@ -2,9 +2,13 @@ package com.livefast.eattrash.raccoonforlemmy.domain.identity.repository
 
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginResponse
+import com.livefast.eattrash.raccoonforlemmy.core.api.dto.SuccessResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforlemmy.core.api.service.v3.AuthServiceV3
+import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.AccountServiceV4
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.utils.SiteVersionDataSource
+import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -20,43 +24,197 @@ class DefaultAuthRepositoryTest {
     val dispatcherTestRule = DispatcherTestRule()
 
     private val authServiceV3 = mockk<AuthServiceV3>()
+    private val accountServiceV4 = mockk<AccountServiceV4>()
     private val serviceProvider =
         mockk<ServiceProvider>(relaxUnitFun = true) {
             every { v3 } returns mockk { every { auth } returns authServiceV3 }
+            every { v4 } returns mockk { every { account } returns accountServiceV4 }
+        }
+    private val siteVersionDataSource =
+        mockk<SiteVersionDataSource> {
+            coEvery {
+                isAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any(),
+                )
+            } returns false
         }
 
     private val sut =
         DefaultAuthRepository(
             services = serviceProvider,
+            siteVersionDataSource = siteVersionDataSource,
         )
 
+    // region V3
     @Test
-    fun whenLogin_thenResultIsAsExpected() =
+    fun givenV3AndSuccess_whenLogin_thenResultIsAsExpected() =
         runTest {
             val loginData = LoginResponse(token = "")
             coEvery { authServiceV3.login(any()) } returns loginData
+
             val res = sut.login("username", "password")
 
             assertTrue(res.isSuccess)
-
             val resultData = res.getOrThrow()
             assertEquals(loginData, resultData)
             coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
                 authServiceV3.login(LoginForm("username", "password"))
+                accountServiceV4 wasNot Called
             }
         }
 
     @Test
-    fun givenFailure_whenLogin_thenResultIsAsExpected() =
+    fun givenV3AndFailure_whenLogin_thenResultIsAsExpected() =
         runTest {
             val loginData = LoginResponse(error = "fake-error-message")
             coEvery { authServiceV3.login(any()) } returns loginData
+
             val res = sut.login("username", "password")
 
             val resultData = res.getOrThrow()
             assertEquals(loginData, resultData)
             coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
                 authServiceV3.login(LoginForm("username", "password"))
+                accountServiceV4 wasNot Called
             }
         }
+
+    @Test
+    fun givenV3AndSuccess_whenLogout_thenResultIsAsExpected() =
+        runTest {
+            val response = SuccessResponse(success = true)
+            coEvery { authServiceV3.logout() } returns response
+
+            val res = sut.logout()
+
+            assertTrue(res.isSuccess)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                authServiceV3.logout()
+                accountServiceV4 wasNot Called
+            }
+        }
+
+    @Test
+    fun givenV3AndFailure_whenLogout_thenResultIsAsExpected() =
+        runTest {
+            val response = SuccessResponse(success = false)
+            coEvery { authServiceV3.logout() } returns response
+
+            val res = sut.logout()
+
+            assertTrue(res.isFailure)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                authServiceV3.logout()
+                accountServiceV4 wasNot Called
+            }
+        }
+    // endregion
+
+    // region V4
+    @Test
+    fun givenV4AndSuccess_whenLogin_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                siteVersionDataSource.isAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
+            } returns true
+            val loginData = LoginResponse(token = "")
+            coEvery { accountServiceV4.login(any()) } returns loginData
+
+            val res = sut.login("username", "password")
+
+            assertTrue(res.isSuccess)
+            val resultData = res.getOrThrow()
+            assertEquals(loginData, resultData)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                accountServiceV4.login(LoginForm("username", "password"))
+                authServiceV3 wasNot Called
+            }
+        }
+
+    @Test
+    fun givenV4AndFailure_whenLogin_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                siteVersionDataSource.isAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
+            } returns true
+            val loginData = LoginResponse(error = "fake-error-message")
+            coEvery { accountServiceV4.login(any()) } returns loginData
+
+            val res = sut.login("username", "password")
+
+            val resultData = res.getOrThrow()
+            assertEquals(loginData, resultData)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                accountServiceV4.login(LoginForm("username", "password"))
+                authServiceV3 wasNot Called
+            }
+        }
+
+    @Test
+    fun givenV4AndSuccess_whenLogout_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                siteVersionDataSource.isAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
+            } returns true
+            val response = SuccessResponse(success = true)
+            coEvery { accountServiceV4.logout() } returns response
+
+            val res = sut.logout()
+
+            assertTrue(res.isSuccess)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                accountServiceV4.logout()
+                authServiceV3 wasNot Called
+            }
+        }
+
+    @Test
+    fun givenV4AndFailure_whenLogout_thenResultIsAsExpected() =
+        runTest {
+            coEvery {
+                siteVersionDataSource.isAtLeast(
+                    major = any(),
+                    minor = any(),
+                    patch = any(),
+                    otherInstance = any()
+                )
+            } returns true
+            val response = SuccessResponse(success = false)
+            coEvery { accountServiceV4.logout() } returns response
+
+            val res = sut.logout()
+
+            assertTrue(res.isFailure)
+            coVerify {
+                siteVersionDataSource.isAtLeast(major = 1, minor = 0, patch = 0)
+                accountServiceV4.logout()
+                authServiceV3 wasNot Called
+            }
+        }
+    // endregion
 }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -150,6 +150,7 @@ val identityModule =
                 DefaultLogoutUseCase(
                     identityRepository = instance(),
                     accountRepository = instance(),
+                    authRepository = instance(),
                     notificationCenter = instance(),
                     settingsRepository = instance(),
                     communitySortRepository = instance(),

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -47,6 +47,7 @@ val identityModule =
             singleton {
                 DefaultAuthRepository(
                     services = instance(tag = "default"),
+                    siteVersionDataSource = instance(),
                 )
             }
         }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/AuthRepository.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/AuthRepository.kt
@@ -8,4 +8,6 @@ interface AuthRepository {
         password: String,
         totp2faToken: String? = null,
     ): Result<LoginResponse>
+
+    suspend fun logout(): Result<Unit>
 }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultAuthRepository.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultAuthRepository.kt
@@ -3,12 +3,15 @@ package com.livefast.eattrash.raccoonforlemmy.domain.identity.repository
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginForm
 import com.livefast.eattrash.raccoonforlemmy.core.api.dto.LoginResponse
 import com.livefast.eattrash.raccoonforlemmy.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.utils.SiteVersionDataSource
+import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.utils.shouldUseV4
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
 internal class DefaultAuthRepository(
     private val services: ServiceProvider,
+    private val siteVersionDataSource: SiteVersionDataSource,
 ) : AuthRepository {
     override suspend fun login(
         username: String,
@@ -23,7 +26,25 @@ internal class DefaultAuthRepository(
                         password = password,
                         totp2faToken = totp2faToken,
                     )
-                services.v3.auth.login(data)
+                if (siteVersionDataSource.shouldUseV4()) {
+                    services.v4.account.login(data)
+                } else {
+                    services.v3.auth.login(data)
+                }
             }
         }
+
+    override suspend fun logout() =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val response =
+                    if (siteVersionDataSource.shouldUseV4()) {
+                        services.v4.account.logout()
+                    } else {
+                        services.v3.auth.logout()
+                    }
+                require(response.success)
+            }
+        }
+
 }

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -9,6 +9,8 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.Communi
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.PostLastSeenDateRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserSortRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.AuthRepository
+import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.DefaultAuthRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
@@ -16,6 +18,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelp
 internal class DefaultLogoutUseCase(
     private val identityRepository: IdentityRepository,
     private val accountRepository: AccountRepository,
+    private val authRepository: AuthRepository,
     private val notificationCenter: NotificationCenter,
     private val settingsRepository: SettingsRepository,
     private val communitySortRepository: CommunitySortRepository,
@@ -29,6 +32,7 @@ internal class DefaultLogoutUseCase(
         notificationCenter.send(NotificationCenterEvent.ResetExplore)
         notificationCenter.send(NotificationCenterEvent.ResetHome)
 
+        authRepository.logout()
         identityRepository.clearToken()
         communitySortRepository.clear()
         userSortRepository.clear()

--- a/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/SiteVersionDataSource.kt
+++ b/domain/lemmy/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/repository/utils/SiteVersionDataSource.kt
@@ -9,7 +9,7 @@ interface SiteVersionDataSource {
     ): Boolean
 }
 
-internal suspend fun SiteVersionDataSource.shouldUseV4(otherInstance: String? = null): Boolean =
+suspend fun SiteVersionDataSource.shouldUseV4(otherInstance: String? = null): Boolean =
     isAtLeast(
         otherInstance = otherInstance,
         major = 1,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds the possibility to use the new POST `v4/account/auth/login` and POST `v4/account/auth/logout` endpoints (replacing the old POST `v3/user/login` and POST `v3/user/logout`).

This is another required step in the migration towards Lemmy 1.0.0 (see #349).
