### PR TITLE
fix: back navigation transition

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,7 +105,6 @@ sqldelight-native = { module = "app.cash.sqldelight:native-driver", version.ref 
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
 voyager-tab = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
-voyager-transition = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 voyager-kodein = { module = "cafe.adriel.voyager:voyager-kodein", version.ref = "voyager" }
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
-                implementation(libs.voyager.transition)
                 implementation(libs.voyager.tab)
 
                 implementation(projects.core.api)

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/App.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.toSize
+import cafe.adriel.voyager.navigator.CurrentScreen
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.TabNavigator
-import cafe.adriel.voyager.transitions.SlideTransition
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toColor
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toCommentBarTheme
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.toPostLayout
@@ -103,7 +103,7 @@ fun App(onLoadingFinished: () -> Unit = {}) = withDI(RootDI.di) {
     val fallbackUriHandler = LocalUriHandler.current
     val customUriHandler = remember { getCustomUriHandler(fallbackUriHandler) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(settingsRepository) {
         val lastActiveAccount = accountRepository.getActive()
         val lastInstance = lastActiveAccount?.instance?.takeIf { it.isNotEmpty() }
         val accountId = lastActiveAccount?.id
@@ -256,10 +256,10 @@ fun App(onLoadingFinished: () -> Unit = {}) = withDI(RootDI.di) {
             ProvideCustomUriHandler {
                 CompositionLocalProvider(
                     LocalDensity provides
-                        Density(
-                            density = LocalDensity.current.density,
-                            fontScale = uiFontScale,
-                        ),
+                            Density(
+                                density = LocalDensity.current.density,
+                                fontScale = uiFontScale,
+                            ),
                 ) {
                     Navigator(
                         screen = MainScreen,
@@ -282,10 +282,9 @@ fun App(onLoadingFinished: () -> Unit = {}) = withDI(RootDI.di) {
                             callback?.let { it() } ?: true
                         },
                     ) { navigator ->
-                        LaunchedEffect(Unit) {
+                        LaunchedEffect(navigationCoordinator) {
                             navigationCoordinator.setRootNavigator(navigator)
                         }
-
                         ModalNavigationDrawer(
                             modifier =
                                 Modifier
@@ -301,16 +300,7 @@ fun App(onLoadingFinished: () -> Unit = {}) = withDI(RootDI.di) {
                                 }
                             },
                         ) {
-                            if (hasBeenInitialized) {
-                                SlideTransition(
-                                    animationSpec =
-                                        tween(
-                                            durationMillis = 250,
-                                            easing = FastOutSlowInEasing,
-                                        ),
-                                    navigator = navigator,
-                                )
-                            }
+                            CurrentScreen()
                         }
 
                         // scrim for draggable side menu


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes the `voyager-transitions` dependency and the `SlideTransition` in the main `Navigator`. This is because after #410, which introduced `kodein-compose` and wrapped the content in a `withDi` Composable, the back navigation was broken.
