### PR TITLE
fix: status bar inset and color

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/appearance/theme/DefaultBarColorProvider.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforlemmy.core.appearance.theme
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
@@ -49,11 +50,13 @@ internal class DefaultBarColorProvider :
                     isAppearanceLightStatusBars =
                         when (theme) {
                             UiTheme.Light -> true
+                            UiTheme.Default -> !isSystemInDarkTheme
                             else -> false
                         }
                     isAppearanceLightNavigationBars =
                         when (theme) {
                             UiTheme.Light -> true
+                            UiTheme.Default -> !isSystemInDarkTheme
                             else -> false
                         }
                 }
@@ -66,15 +69,9 @@ internal class DefaultBarColorProvider :
         theme: UiTheme,
         barTheme: UiBarTheme,
     ) {
-        if (barTheme == UiBarTheme.Transparent) {
-            return
-        }
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            return
-        }
-
         val decorView = activity.window.decorView
-        val isSystemInDarkTheme = activity.resources.configuration.isNightModeActive
+        val uiMode = activity.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isSystemInDarkTheme = uiMode == Configuration.UI_MODE_NIGHT_YES
         val baseColor = theme.getBaseColor(isSystemInDarkTheme)
         val barColor = barTheme.getBarColor(baseColor).toArgb()
 

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/main/MainScreen.kt
@@ -208,10 +208,10 @@ internal object MainScreen : Screen {
                 bottomBar = {
                     CompositionLocalProvider(
                         LocalDensity provides
-                            Density(
-                                density = LocalDensity.current.density,
-                                fontScale = uiFontScale,
-                            ),
+                                Density(
+                                    density = LocalDensity.current.density,
+                                    fontScale = uiFontScale,
+                                ),
                     ) {
                         val titleVisible by themeRepository.navItemTitles.collectAsState()
                         var uiFontSizeWorkaround by remember { mutableStateOf(true) }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes the colors of the status bar (depending on the theme), plus it also fixes the insets on newer versions of Android.
