### PR TITLE
chore: read ktlint-compose-rules from version catalog

### DIFF
--- a/build-logic/convention/src/main/kotlin/plugins/SpotlessPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/SpotlessPlugin.kt
@@ -27,7 +27,9 @@ class SpotlessPlugin : Plugin<Project> {
                         )
                         .customRuleSets(
                             listOf(
-                                "io.nlopez.compose.rules:ktlint:0.4.22",
+                                libs.findLibrary("ktlint-compose-rules").dependency.let { dep ->
+                                    "${dep.group}:${dep.name}:${dep.version}"
+                                },
                             ),
                         )
                     trimTrailingWhitespace()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinx-serialization-json = "1.8.1"
 kover = "0.9.1"
 ksp = "2.1.21-2.0.1"
 ktlint = "1.6.0"
+ktlint-compose-rules = "0.4.22"
 ktor = "3.1.3"
 ktorfit = "2.5.2"
 materialKolor = "2.1.1"
@@ -75,6 +76,8 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+
+ktlint-compose-rules = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlint-compose-rules" }
 
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR removes the hardcoded `io.nlopez.compose.rules:ktlint:0.4.22` string from `SpotlessPlugin` and reads it from the version catalog.
