### PR TITLE
refactor: improve observability

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
@@ -30,11 +30,10 @@ internal class DefaultServiceProvider(
     private val factory: HttpClientEngine,
     private val appInfoRepository: AppInfoRepository,
 ) : ServiceProvider {
-    companion object {
-        private const val DEFAULT_INSTANCE = "lemmy.world"
-    }
 
-    override var currentInstance: String = DEFAULT_INSTANCE
+    override val defaultInstance: String get() = DEFAULT_INSTANCE
+
+    override var currentInstance: String = defaultInstance
 
     override lateinit var v3: V3
 
@@ -111,5 +110,9 @@ internal class DefaultServiceProvider(
                 v3.site.get()
             }.getOrNull()
         return site?.version.orEmpty()
+    }
+
+    companion object {
+        private const val DEFAULT_INSTANCE = "lemmy.world"
     }
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/ServiceProvider.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.V4
 
 interface ServiceProvider {
     val currentInstance: String
+    val defaultInstance: String
     val v3: V3
     val v4: V4
 

--- a/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultAccountRepositoryTest.kt
+++ b/core/persistence/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultAccountRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import kotlin.test.Test
@@ -53,11 +54,12 @@ class DefaultAccountRepositoryTest {
     @Test
     fun givenExitingAccounts_whenObserveAll_thenResultIsAsExpected() = runTest {
         val accounts = listOf(createFakeEntity())
-        every { query.executeAsList() } returns accounts
+        every { dao.observeAll() } returns flowOf(accounts)
 
         sut.observeAll().test {
             val res = awaitItem()
             assertTrue(res.size == 1)
+            cancelAndConsumeRemainingEvents()
         }
     }
 

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/AccountDao.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/AccountDao.kt
@@ -2,13 +2,18 @@ package com.livefast.eattrash.raccoonforlemmy.core.persistence.dao
 
 import app.cash.sqldelight.Query
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.AccountEntity
+import kotlinx.coroutines.flow.Flow
 
 interface AccountDao {
     fun getAll(): Query<AccountEntity>
 
+    fun observeAll(): Flow<List<AccountEntity>>
+
     fun getBy(username: String?, instance: String?): Query<AccountEntity>
 
     fun getActive(): Query<AccountEntity>
+
+    fun observeActive(): Flow<AccountEntity?>
 
     fun create(username: String, instance: String, jwt: String?, avatar: String?)
 

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/DefaultAccountDao.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/DefaultAccountDao.kt
@@ -3,13 +3,18 @@ package com.livefast.eattrash.raccoonforlemmy.core.persistence.dao
 import app.cash.sqldelight.Query
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.AccountEntity
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.AccountsQueries
+import kotlinx.coroutines.flow.Flow
 
 internal class DefaultAccountDao(private val queries: AccountsQueries) : AccountDao {
     override fun getAll(): Query<AccountEntity> = queries.getAll()
 
+    override fun observeAll(): Flow<List<AccountEntity>> = queries.getAll().observeMany()
+
     override fun getBy(username: String?, instance: String?): Query<AccountEntity> = queries.getBy(username, instance)
 
     override fun getActive(): Query<AccountEntity> = queries.getActive()
+
+    override fun observeActive(): Flow<AccountEntity?> = queries.getActive().observeOne()
 
     override fun create(username: String, instance: String, jwt: String?, avatar: String?) {
         queries.create(username, instance, jwt, avatar)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/Extensions.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/dao/Extensions.kt
@@ -1,0 +1,50 @@
+package com.livefast.eattrash.raccoonforlemmy.core.persistence.dao
+
+import app.cash.sqldelight.Query
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Observe the results of a query returning a list of items.
+ */
+internal fun <T : Any> Query<T>.observeMany(): Flow<List<T>> = callbackFlow {
+    fun fetchResult() {
+        val result = executeAsList()
+        trySend(result)
+    }
+
+    val resultListener = object : Query.Listener {
+        override fun queryResultsChanged() {
+            fetchResult()
+        }
+    }
+    fetchResult()
+    addListener(resultListener)
+
+    awaitClose {
+        removeListener(resultListener)
+    }
+}
+
+/**
+ * Observe the results of a query returning a single item (or null if no item satisfies the criteria).
+ */
+internal fun <T : Any> Query<T>.observeOne(): Flow<T?> = callbackFlow {
+    fun fetchResult() {
+        val result = executeAsOneOrNull()
+        trySend(result)
+    }
+
+    val resultListener = object : Query.Listener {
+        override fun queryResultsChanged() {
+            fetchResult()
+        }
+    }
+    fetchResult()
+    addListener(resultListener)
+
+    awaitClose {
+        removeListener(resultListener)
+    }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultAccountRepository.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/DefaultAccountRepository.kt
@@ -3,11 +3,8 @@ package com.livefast.eattrash.raccoonforlemmy.core.persistence.repository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.AccountEntity
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.dao.AccountDao
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.AccountModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.flow.map
 
 internal class DefaultAccountRepository(private val dao: AccountDao) : AccountRepository {
     override suspend fun getAll(): List<AccountModel> = dao
@@ -15,12 +12,8 @@ internal class DefaultAccountRepository(private val dao: AccountDao) : AccountRe
         .executeAsList()
         .map { it.toModel() }
 
-    override fun observeAll(): Flow<List<AccountModel>> = channelFlow {
-        while (isActive) {
-            send(getAll())
-            delay(1000)
-        }
-    }.distinctUntilChanged()
+    override fun observeAll(): Flow<List<AccountModel>> =
+        dao.observeAll().map { result -> result.map { entity -> entity.toModel() } }
 
     override suspend fun getBy(username: String, instance: String): AccountModel? = dao
         .getBy(username.lowercase(), instance.lowercase())

--- a/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
@@ -15,9 +15,11 @@ class DefaultApiConfigurationRepositoryTest {
     @get:Rule
     val dispatcherTestRule = DispatcherTestRule()
 
+    private val initialInstance = "lemmy.world"
+    private val newInstance = "feddit.it"
     private val serviceProvider =
         mockk<ServiceProvider>(relaxUnitFun = true) {
-            every { currentInstance } returns "lemmy.world"
+            every { defaultInstance } returns initialInstance
         }
     private val keyStore =
         mockk<TemporaryKeyStore>(relaxUnitFun = true) {
@@ -33,13 +35,13 @@ class DefaultApiConfigurationRepositoryTest {
     @Test
     fun whenChangeInstance_thenValueIsUpdated() {
         val resBefore = sut.instance.value
-        assertEquals("", resBefore)
+        assertEquals(initialInstance, resBefore)
 
-        sut.changeInstance("feddit.it")
+        sut.changeInstance(newInstance)
 
         coVerify {
-            serviceProvider.changeInstance("feddit.it")
-            keyStore.save(any(), "feddit.it")
+            serviceProvider.changeInstance(newInstance)
+            keyStore.save(any(), newInstance)
         }
     }
 }

--- a/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
+++ b/domain/identity/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.livefast.eattrash.raccoonforlemmy.domain.identity.usecase
 
-import com.livefast.eattrash.raccoonforlemmy.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.BottomNavItemsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenterEvent
@@ -13,6 +12,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.PostLas
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.UserSortRepository
 import com.livefast.eattrash.raccoonforlemmy.core.testutils.DispatcherTestRule
+import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.LemmyValueCache
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.repository.UserTagHelper
@@ -30,7 +30,7 @@ class DefaultSwitchAccountUseCaseTest {
     private val identityRepository = mockk<IdentityRepository>(relaxUnitFun = true)
     private val accountRepository = mockk<AccountRepository>(relaxUnitFun = true)
     private val settingsRepository = mockk<SettingsRepository>(relaxUnitFun = true)
-    private val serviceProvider = mockk<ServiceProvider>(relaxUnitFun = true)
+    private val apiConfigurationRepository = mockk<ApiConfigurationRepository>(relaxUnitFun = true)
     private val notificationCenter = mockk<NotificationCenter>(relaxUnitFun = true)
     private val communitySortRepository = mockk<CommunitySortRepository>(relaxUnitFun = true)
     private val communityPreferredLanguageRepository =
@@ -47,8 +47,8 @@ class DefaultSwitchAccountUseCaseTest {
         DefaultSwitchAccountUseCase(
             identityRepository = identityRepository,
             accountRepository = accountRepository,
+            apiConfigurationRepository = apiConfigurationRepository,
             settingsRepository = settingsRepository,
-            serviceProvider = serviceProvider,
             notificationCenter = notificationCenter,
             communitySortRepository = communitySortRepository,
             communityPreferredLanguageRepository = communityPreferredLanguageRepository,
@@ -104,7 +104,7 @@ class DefaultSwitchAccountUseCaseTest {
             notificationCenter.send(ofType(NotificationCenterEvent.Logout::class))
             identityRepository.storeToken("new-token")
             identityRepository.refreshLoggedState()
-            serviceProvider.changeInstance("new-instance")
+            apiConfigurationRepository.changeInstance("new-instance")
             userTagHelper.clear()
             userSortRepository.clear()
             postLastSeenDateRepository.clear()

--- a/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
+++ b/domain/identity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/identity/di/IdentityModule.kt
@@ -167,7 +167,7 @@ val identityModule =
                 DefaultSwitchAccountUseCase(
                     identityRepository = instance(),
                     accountRepository = instance(),
-                    serviceProvider = instance("default"),
+                    apiConfigurationRepository = instance(),
                     notificationCenter = instance(),
                     settingsRepository = instance(),
                     communitySortRepository = instance(),

--- a/unit/managesubscriptions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/managesubscriptions/di/ManageSubscriptionsModule.kt
+++ b/unit/managesubscriptions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/managesubscriptions/di/ManageSubscriptionsModule.kt
@@ -1,12 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.unit.managesubscriptions.di
 
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.di.bindViewModel
-import com.livefast.eattrash.raccoonforlemmy.unit.managesubscriptions.ManageSubscriptionsMviModel
 import com.livefast.eattrash.raccoonforlemmy.unit.managesubscriptions.ManageSubscriptionsViewModel
 import org.kodein.di.DI
-import org.kodein.di.bind
 import org.kodein.di.instance
-import org.kodein.di.provider
 
 val manageSubscriptionsModule =
     DI.Module("ManageSubscriptionsModule") {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR makes it possible to easily observe data changes from the local DB. This is going to be used in the future to improve app startup and account change scenarios.

Moreover, since we're at it, this also removes some other workaround to register observers for changes (e.g. the current instance).
