### PR TITLE
refactor: add version to remote app config

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/di/ApiModule.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/di/ApiModule.kt
@@ -27,6 +27,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.api.service.v4.SiteServiceV4
 import com.livefast.eattrash.raccoonforlemmy.core.utils.network.provideHttpClientEngine
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
+import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.factory
@@ -40,6 +41,14 @@ val apiModule =
         bind<HttpClientEngine> {
             singleton {
                 provideHttpClientEngine()
+            }
+        }
+        bind<Json> {
+            singleton {
+                Json {
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                }
             }
         }
         bind<AuthServiceV3> {
@@ -102,6 +111,7 @@ val apiModule =
                 DefaultServiceProvider(
                     factory = instance(),
                     appInfoRepository = instance(),
+                    json = instance(),
                 )
             }
         }
@@ -110,6 +120,7 @@ val apiModule =
                 DefaultServiceProvider(
                     factory = instance(),
                     appInfoRepository = instance(),
+                    json = instance(),
                 )
             }
         }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/api/provider/DefaultServiceProvider.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.Json
 internal class DefaultServiceProvider(
     private val factory: HttpClientEngine,
     private val appInfoRepository: AppInfoRepository,
+    private val json: Json,
 ) : ServiceProvider {
 
     override val defaultInstance: String get() = DEFAULT_INSTANCE
@@ -74,12 +75,7 @@ internal class DefaultServiceProvider(
                     }
                 }
                 install(ContentNegotiation) {
-                    json(
-                        Json {
-                            isLenient = true
-                            ignoreUnknownKeys = true
-                        },
-                    )
+                    json(json)
                 }
             }
         val serviceArgs = ServiceCreationArgs(baseUrl, client)

--- a/core/preferences/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/appconfig/RemoteAppConfigDataSourceTest.kt
+++ b/core/preferences/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/appconfig/RemoteAppConfigDataSourceTest.kt
@@ -7,8 +7,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.Rule
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class RemoteAppConfigDataSourceTest {
@@ -23,13 +25,13 @@ class RemoteAppConfigDataSourceTest {
                 headers = headersOf(HttpHeaders.ContentType, "application/json"),
             )
         }
-    private val sut =
-        RemoteAppConfigDataSource(factory = mockEngine)
+    private val sut = RemoteAppConfigDataSource(engine = mockEngine, json = Json)
 
     @Test
     fun whenGet_thenResultIsAsExpected() = runTest {
         val res = sut.get()
 
         assertTrue(res.alternateMarkdownRenderingSettingsItemEnabled)
+        assertEquals(0, res.version)
     }
 }

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/appconfig/AppConfig.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/appconfig/AppConfig.kt
@@ -1,3 +1,3 @@
 package com.livefast.eattrash.raccoonforlemmy.core.preferences.appconfig
 
-data class AppConfig(val alternateMarkdownRenderingSettingsItemEnabled: Boolean = false)
+data class AppConfig(val alternateMarkdownRenderingSettingsItemEnabled: Boolean = false, val version: Int = 0)

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/di/AppConfigModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/preferences/di/AppConfigModule.kt
@@ -29,7 +29,10 @@ internal val appConfigModule =
         }
         bind<AppConfigDataSource>(tag = "remote") {
             singleton {
-                RemoteAppConfigDataSource()
+                RemoteAppConfigDataSource(
+                    engine = instance(),
+                    json = instance(),
+                )
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,8 +35,8 @@ sqlcipher = "4.9.0"
 sqldelight = "2.1.0"
 turbine = "1.2.1"
 
-android-targetSdk = "35"
-android-compileSdk = "35"
+android-targetSdk = "36"
+android-compileSdk = "36"
 android-minSdk = "26"
 
 [libraries]


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR adds the `version` field to the AppConfig object, which will be needed for future implementations/migration.
