### PR TITLE
fix(di): make sure unique tags are used for ViewModel bindings

### DIFF
--- a/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/architecture/di/GetViewModel.kt
+++ b/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/architecture/di/GetViewModel.kt
@@ -48,13 +48,13 @@ internal class CustomViewModelFactory(private val injector: DI) : ViewModelProvi
         val argument = extras[VM_ARG_KEY]
         if (argument != null) {
             val model by injector.instance<ViewModelCreationArgs, ViewModel>(
-                tag = modelClass.simpleName,
+                tag = modelClass.diKey,
                 arg = argument,
             )
             return modelClass.cast(model)
         }
 
-        val model by injector.instance<ViewModel>(tag = modelClass.simpleName)
+        val model by injector.instance<ViewModel>(tag = modelClass.diKey)
         return modelClass.cast(model)
     }
 }
@@ -63,3 +63,9 @@ internal class CustomViewModelFactory(private val injector: DI) : ViewModelProvi
  * Key used to store the [ViewModelCreationArgs] in the [CreationExtras] to instantiate the [ViewModel].
  */
 val VM_ARG_KEY = object : CreationExtras.Key<ViewModelCreationArgs> {}
+
+/**
+ * Return the DI key to be used for a [ViewModel] for DI.
+ */
+val <T : ViewModel> KClass<T>.diKey: String?
+    get() = qualifiedName

--- a/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/architecture/di/ViewModelBindUtils.kt
+++ b/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/architecture/di/ViewModelBindUtils.kt
@@ -21,7 +21,7 @@ inline fun <reified T : ViewModel> DI.Builder.bindViewModel(
     noinline block: NoArgBindingDI<*>.() -> T,
 ) {
     bind<T>(
-        tag = T::class.simpleName,
+        tag = T::class.diKey,
         overrides = overrides,
     ) {
         provider<Any, T> {
@@ -43,7 +43,7 @@ inline fun <reified A : ViewModelCreationArgs, reified T : ViewModel> DI.Builder
     noinline block: BindingDI<*>.(A) -> T,
 ) {
     bind<T>(
-        tag = T::class.simpleName,
+        tag = T::class.diKey,
         overrides = overrides,
     ) {
         factory<Any, ViewModelCreationArgs, T> { args: ViewModelCreationArgs ->


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR makes sure there are no overlapping DI tags for `ViewModel` bindings, which could happen with code obfuscation in release builds if the class `simpleName` were used. Switching to `qualifiedName` solves the issue.
