### PR TITLE
chore: migrate from ClipboardManager to Clipboard

### DIFF
--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/CommentCard.kt
@@ -19,10 +19,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
@@ -42,12 +43,14 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ancillaryText
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomizedContent
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.texttoolbar.getCustomTextToolbar
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommentModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
+import kotlinx.coroutines.launch
 
 private val BAR_BASE_WIDTH_UNIT = 1.25.dp
 private const val COMMENT_TEXT_SCALE_FACTOR = 0.97f
@@ -108,10 +111,14 @@ fun CommentCard(
             0.dp
         }
     val shareHelper = remember { getShareHelper() }
-    val clipboardManager = LocalClipboardManager.current
-    val onShareLambda = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        shareHelper.share(query)
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
+    val scope = rememberCoroutineScope()
+    val onShareLambda: () -> Unit = {
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            shareHelper.share(query)
+        }
     }
     val shareActionLabel = LocalStrings.current.postActionShare
     val cancelActionLabel = LocalStrings.current.buttonCancel

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/InboxCard.kt
@@ -15,11 +15,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -35,12 +36,14 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ancillaryText
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.CustomizedContent
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.texttoolbar.getCustomTextToolbar
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PersonMentionModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
+import kotlinx.coroutines.launch
 
 sealed interface InboxCardType {
     data object Mention : InboxCardType
@@ -76,10 +79,14 @@ fun InboxCard(
         onClick.invoke(mention.post)
     }
     val shareHelper = remember { getShareHelper() }
-    val clipboardManager = LocalClipboardManager.current
-    val onShareLambda = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        shareHelper.share(query)
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
+    val scope = rememberCoroutineScope()
+    val onShareLambda: () -> Unit = {
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            shareHelper.share(query)
+        }
     }
     val shareActionLabel = LocalStrings.current.postActionShare
     val cancelActionLabel = LocalStrings.current.buttonCancel

--- a/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
+++ b/core/commonui/lemmyui/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/commonui/lemmyui/PostCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,7 +31,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.LocalUriHandler
@@ -50,6 +51,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.components.Customized
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAVideo
 import com.livefast.eattrash.raccoonforlemmy.core.utils.looksLikeAnImage
@@ -60,6 +62,7 @@ import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.PostModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.UserModel
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.imageUrl
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.videoUrl
+import kotlinx.coroutines.launch
 
 @Composable
 fun PostCard(
@@ -351,10 +354,14 @@ private fun CompactPost(
             .takeIf { !it.looksLikeAnImage && !it.looksLikeAVideo }
             .orEmpty()
     val shareHelper = remember { getShareHelper() }
-    val clipboardManager = LocalClipboardManager.current
-    val onShareLambda = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        shareHelper.share(query)
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
+    val scope = rememberCoroutineScope()
+    val onShareLambda: () -> Unit = {
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            shareHelper.share(query)
+        }
     }
     val shareActionLabel = LocalStrings.current.postActionShare
     val cancelActionLabel = LocalStrings.current.buttonCancel
@@ -596,10 +603,14 @@ private fun ExtendedPost(
                     !it.looksLikeAVideo
             }.orEmpty()
     val shareHelper = remember { getShareHelper() }
-    val clipboardManager = LocalClipboardManager.current
-    val onShareLambda = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        shareHelper.share(query)
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
+    val scope = rememberCoroutineScope()
+    val onShareLambda: () -> Unit = {
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            shareHelper.share(query)
+        }
     }
     val shareActionLabel = LocalStrings.current.postActionShare
     val cancelActionLabel = LocalStrings.current.buttonCancel

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/DefaultClipboardHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/DefaultClipboardHelper.kt
@@ -1,0 +1,25 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard
+
+import android.content.ClipData
+import android.content.Context
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.toClipEntry
+
+class DefaultClipboardHelper(
+    private val clipboard: Clipboard,
+    private val context: Context,
+) : ClipboardHelper {
+    override suspend fun setText(text: String) {
+        val newEntry = ClipData.newPlainText("", text).toClipEntry()
+        clipboard.setClipEntry(newEntry)
+    }
+
+    override suspend fun getText(): String? {
+        val data = clipboard.getClipEntry()?.clipData ?: return null
+        val count = data.itemCount
+        check(count > 0) { return null }
+
+        val item = data.getItemAt(count - 1)
+        return item.coerceToText(context).toString()
+    }
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import androidx.compose.ui.platform.Clipboard
+import com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard.ClipboardHelper
+import com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard.DefaultClipboardHelper
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.factory
+import org.kodein.di.instance
+import org.kodein.di.provider
+import org.kodein.di.singleton
+
+actual val nativeClipboardModule = DI.Module("NativeClipboardModule") {
+    bind<ClipboardHelper> {
+        factory<Any, Clipboard, ClipboardHelper> { clipboard: Clipboard ->
+            DefaultClipboardHelper(
+                clipboard = clipboard,
+                context = instance(),
+            )
+        }
+    }
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/ClipboardHelper.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/ClipboardHelper.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard
+
+interface ClipboardHelper {
+    suspend fun setText(text: String)
+
+    suspend fun getText(): String?
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import org.kodein.di.DI
+
+internal expect val nativeClipboardModule: DI.Module

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/Utils.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforlemmy.core.utils.di
 
+import androidx.compose.ui.platform.Clipboard
 import com.livefast.eattrash.raccoonforlemmy.core.di.RootDI
+import com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard.ClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.fs.FileSystemManager
 import com.livefast.eattrash.raccoonforlemmy.core.utils.gallery.GalleryHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.imageload.ImageLoaderProvider
@@ -26,3 +28,9 @@ fun getShareHelper(): ShareHelper {
     val res by RootDI.di.instance<ShareHelper>()
     return res
 }
+
+fun getClipboardHelper(clipboard: Clipboard): ClipboardHelper {
+    val res by RootDI.di.instance<Clipboard, ClipboardHelper>(arg = clipboard)
+    return res
+}
+

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/UtilsModule.kt
@@ -15,6 +15,7 @@ val utilsModule =
     DI.Module("UtilsModule") {
         importAll(
             nativeAppIconModule,
+            nativeClipboardModule,
             nativeCrashReportModule,
             nativeCustomTabsModule,
             nativeFileSystemModule,

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/DefaultClipboardHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/clipboard/DefaultClipboardHelper.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+
+@OptIn(ExperimentalComposeUiApi::class)
+class DefaultClipboardHelper(
+    private val clipboard: Clipboard,
+) : ClipboardHelper {
+
+    override suspend fun setText(text: String) {
+        val newEntry = ClipEntry.withPlainText(text)
+        clipboard.setClipEntry(newEntry)
+    }
+
+    override suspend fun getText(): String? =
+        clipboard.getClipEntry()?.getPlainText()
+}

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforlemmy.core.utils.di
+
+import androidx.compose.ui.platform.Clipboard
+import com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard.ClipboardHelper
+import com.livefast.eattrash.raccoonforlemmy.core.utils.clipboard.DefaultClipboardHelper
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.factory
+
+actual val nativeClipboardModule = DI.Module("NativeClipboardModule") {
+    bind<ClipboardHelper> {
+        factory<Any, Clipboard, ClipboardHelper> { clipboard: Clipboard ->
+            DefaultClipboardHelper(clipboard = clipboard)
+        }
+    }
+}

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -68,9 +68,8 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -103,6 +102,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoo
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.keepscreenon.rememberKeepScreenOn
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
@@ -160,7 +160,8 @@ fun CommunityDetailScreen(communityId: Long, modifier: Modifier = Modifier, othe
     val settings by settingsRepository.currentSettings.collectAsState()
     val keepScreenOn = rememberKeepScreenOn()
     val mainRouter = remember { getMainRouter() }
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     val focusManager = LocalFocusManager.current
     val keyboardScrollConnection =
         remember {
@@ -1235,7 +1236,9 @@ fun CommunityDetailScreen(communityId: Long, modifier: Modifier = Modifier, othe
                                                             post.text.takeIf { it.isNotBlank() },
                                                         ).distinct()
                                                     if (texts.size == 1) {
-                                                        clipboardManager.setText(AnnotatedString(texts.first()))
+                                                        scope.launch {
+                                                            clipboardHelper.setText(texts.first())
+                                                        }
                                                     } else {
                                                         copyPostBottomSheet = post
                                                     }
@@ -1575,8 +1578,9 @@ fun CommunityDetailScreen(communityId: Long, modifier: Modifier = Modifier, othe
             onSelect = { index ->
                 copyPostBottomSheet = null
                 if (index != null) {
-                    val text = texts[index]
-                    clipboardManager.setText(AnnotatedString(text))
+                    scope.launch {
+                        clipboardHelper.setText(texts[index])
+                    }
                 }
             },
         )

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -74,10 +74,9 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -117,6 +116,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepo
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.core.utils.datetime.toTimestamp
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
@@ -179,7 +179,8 @@ fun PostDetailScreen(
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
     val mainRouter = remember { getMainRouter() }
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     val focusManager = LocalFocusManager.current
     val keyboardScrollConnection =
         remember {
@@ -537,7 +538,9 @@ fun PostDetailScreen(
                                                         uiState.post.text.takeIf { it.isNotBlank() },
                                                     ).distinct()
                                                 if (texts.size == 1) {
-                                                    clipboardManager.setText(AnnotatedString(texts.first()))
+                                                    scope.launch {
+                                                        clipboardHelper.setText(texts.first())
+                                                    }
                                                 } else {
                                                     copyPostBottomSheet = uiState.post
                                                 }
@@ -2001,8 +2004,9 @@ fun PostDetailScreen(
             onSelect = { index ->
                 copyPostBottomSheet = null
                 if (index != null) {
-                    val text = texts[index]
-                    clipboardManager.setText(AnnotatedString(text))
+                    scope.launch {
+                        clipboardHelper.setText(texts[index])
+                    }
                 }
             },
         )

--- a/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
+++ b/unit/postlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postlist/PostListScreen.kt
@@ -55,9 +55,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.data.PostLayout
@@ -89,6 +88,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificati
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.keepscreenon.rememberKeepScreenOn
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
@@ -142,7 +142,8 @@ fun PostListScreen(
         with(LocalDensity.current) {
             WindowInsets.navigationBars.getBottom(this).toDp()
         }
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var itemIdToDelete by remember { mutableStateOf<Long?>(null) }
     var listingTypeBottomSheetOpened by remember { mutableStateOf(false) }
     var shareBottomSheetUrls by remember { mutableStateOf<List<String>?>(null) }
@@ -740,7 +741,9 @@ fun PostListScreen(
                                                         post.text.takeIf { it.isNotBlank() },
                                                     ).distinct()
                                                 if (texts.size == 1) {
-                                                    clipboardManager.setText(AnnotatedString(texts.first()))
+                                                    scope.launch {
+                                                        clipboardHelper.setText(texts.first())
+                                                    }
                                                 } else {
                                                     copyPostBottomSheet = post
                                                 }
@@ -1043,8 +1046,9 @@ fun PostListScreen(
             onSelect = { index ->
                 copyPostBottomSheet = null
                 if (index != null) {
-                    val text = texts[index]
-                    clipboardManager.setText(AnnotatedString(text))
+                    scope.launch {
+                        clipboardHelper.setText(texts[index])
+                    }
                 }
             },
         )

--- a/unit/rawcontent/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/rawcontent/RawContentDialog.kt
+++ b/unit/rawcontent/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/rawcontent/RawContentDialog.kt
@@ -25,9 +25,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.text.font.FontFamily
@@ -36,10 +37,12 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.texttoolbar.getCustomTextToolbar
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,15 +59,21 @@ fun RawContentDialog(
     upVotes: Int? = null,
     downVotes: Int? = null,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     val shareHelper = remember { getShareHelper() }
+    val scope = rememberCoroutineScope()
     val onShareLambda: () -> Unit = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        shareHelper.share(query)
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            shareHelper.share(query)
+        }
     }
     val onQuoteLambda: () -> Unit = {
-        val query = clipboardManager.getText()?.text.orEmpty()
-        onQuote?.invoke(query)
+        scope.launch {
+            val query = clipboardHelper.getText().orEmpty()
+            onQuote?.invoke(query)
+        }
     }
     val quoteActionLabel =
         if (isLogged) {

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -57,8 +57,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -96,6 +95,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.ValidationError
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
+import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toIcon
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toLocalDp
 import com.livefast.eattrash.raccoonforlemmy.core.utils.toModifier
@@ -145,7 +145,8 @@ fun UserDetailScreen(userId: Long, modifier: Modifier = Modifier, otherInstance:
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
     val mainRouter = remember { getMainRouter() }
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var shareBottomSheetUrls by remember { mutableStateOf<List<String>?>(null) }
     var sortBottomSheetOpened by remember { mutableStateOf(false) }
     var defaultSortBottomSheetOpened by remember { mutableStateOf(false) }
@@ -782,7 +783,9 @@ fun UserDetailScreen(userId: Long, modifier: Modifier = Modifier, otherInstance:
                                                         post.text.takeIf { it.isNotBlank() },
                                                     ).distinct()
                                                 if (texts.size == 1) {
-                                                    clipboardManager.setText(AnnotatedString(texts.first()))
+                                                    scope.launch {
+                                                        clipboardHelper.setText(texts.first())
+                                                    }
                                                 } else {
                                                     copyPostBottomSheet = post
                                                 }
@@ -1264,8 +1267,9 @@ fun UserDetailScreen(userId: Long, modifier: Modifier = Modifier, otherInstance:
             onSelect = { index ->
                 copyPostBottomSheet = null
                 if (index != null) {
-                    val text = texts[index]
-                    clipboardManager.setText(AnnotatedString(text))
+                    scope.launch {
+                        clipboardHelper.setText(texts[index])
+                    }
                 }
             },
         )


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
Compose 1.8.0 deprecated `ClipboardManager` in favor of `Clipboard`, which exposes a suspending API (changelog [here](https://developer.android.com/jetpack/androidx/releases/compose-ui#1.8.0)).

With a delay of some month, I finally took the time to complete the migration. This involves using a helper (multiplatform) class, because native APIs are not equal (and in iOS it is still experimental).
