### PR TITLE
enhancement: add switch account button on auth failure

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/main/ProfileMainScreen.kt
@@ -183,7 +183,11 @@ fun ProfileMainScreen(
                     },
                 )
 
-                false -> ProfileNotLoggedScreen()
+                false -> ProfileNotLoggedScreen(
+                    onManageAccounts = {
+                        manageAccountsBottomSheetOpened = true
+                    },
+                )
                 else -> Unit
             }
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/notlogged/ProfileNotLoggedScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/profile/notlogged/ProfileNotLoggedScreen.kt
@@ -20,7 +20,7 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getMainRouter
 
 @Composable
-fun ProfileNotLoggedScreen(modifier: Modifier = Modifier) {
+fun ProfileNotLoggedScreen(onManageAccounts: () -> Unit, modifier: Modifier = Modifier) {
     val model: ProfileNotLoggedMviModel = getViewModel<ProfileNotLoggedViewModel>()
     val mainRouter = remember { getMainRouter() }
     val uiState by model.uiState.collectAsState()
@@ -47,6 +47,13 @@ fun ProfileNotLoggedScreen(modifier: Modifier = Modifier) {
                 },
             ) {
                 Text(LocalStrings.current.buttonRetry)
+            }
+
+            Button(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                onClick = onManageAccounts,
+            ) {
+                Text(LocalStrings.current.actionSwitchAccount)
             }
         } else {
             Button(

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.DefaultMviModelDelegate
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.MviModelDelegate
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.utils.ValidationError
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforlemmy.domain.identity.usecase.LogoutUseCase
@@ -25,8 +24,7 @@ class AccountSettingsViewModel(
     private val mediaRepository: MediaRepository,
     private val userRepository: UserRepository,
     private val getSortTypesUseCase: GetSortTypesUseCase,
-    private val logoutUseCase: LogoutUseCase,
-    private val notificationCenter: NotificationCenter,
+    private val logout: LogoutUseCase,
 ) : ViewModel(),
     MviModelDelegate<AccountSettingsMviModel.Intent, AccountSettingsMviModel.UiState, AccountSettingsMviModel.Effect>
     by DefaultMviModelDelegate(initialState = AccountSettingsMviModel.UiState()),
@@ -291,7 +289,7 @@ class AccountSettingsViewModel(
 
             if (success) {
                 emitEffect(AccountSettingsMviModel.Effect.CloseDeleteAccountDialog)
-                logoutUseCase()
+                logout()
                 updateState { it.copy(operationInProgress = false) }
                 emitEffect(AccountSettingsMviModel.Effect.Close)
             } else {
@@ -345,7 +343,7 @@ class AccountSettingsViewModel(
                 emitEffect(
                     AccountSettingsMviModel.Effect.Success,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 updateState { it.copy(loading = false) }
                 emitEffect(
                     AccountSettingsMviModel.Effect.Failure,

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/di/AccountSettingsModule.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/di/AccountSettingsModule.kt
@@ -14,8 +14,7 @@ val accountSettingsModule =
                 mediaRepository = instance(),
                 userRepository = instance(),
                 getSortTypesUseCase = instance(),
-                logoutUseCase = instance(),
-                notificationCenter = instance(),
+                logout = instance(),
             )
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR add a "Switch account" button in the profile screen when there is an authentication issue. This makes it possible to change account when, e.g., your instance is down.