### PR TITLE
fix: settings submit bottom insets

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/inbox/main/InboxScreen.kt
@@ -40,7 +40,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBot
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.unit.mentions.InboxMentionsScreen
 import com.livefast.eattrash.raccoonforlemmy.unit.messages.InboxMessagesScreen
@@ -61,7 +60,6 @@ fun InboxScreen(modifier: Modifier = Modifier, model: InboxMviModel = getViewMod
     val settings by settingsRepository.currentSettings.collectAsState()
     val scope = rememberCoroutineScope()
     val connection = navigationCoordinator.getBottomBarScrollConnection()
-    val notificationCenter = remember { getNotificationCenter() }
     var inboxTypeBottomSheetOpened by remember { mutableStateOf(false) }
     val inboxReadAllSuccessMessage = LocalStrings.current.messageReadAllInboxSuccess
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -60,7 +60,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SliderBottomSh
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.resources.di.getCoreResources
 import com.livefast.eattrash.raccoonforlemmy.core.utils.appicon.AppIconVariant
 import com.livefast.eattrash.raccoonforlemmy.core.utils.appicon.toReadableName
@@ -92,7 +91,6 @@ fun AdvancedSettingsScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val scrollState = rememberScrollState()
-    val notificationCenter = remember { getNotificationCenter() }
     var screenWidth by remember { mutableFloatStateOf(0f) }
     val snackbarHostState = remember { SnackbarHostState() }
     val successMessage = LocalStrings.current.messageOperationSuccessful

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -68,7 +68,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBot
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
@@ -89,7 +88,6 @@ fun SettingsColorAndFontScreen(modifier: Modifier = Modifier) {
     val model: SettingsColorAndFontMviModel = getViewModel<SettingsColorAndFontViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val notificationCenter = remember { getNotificationCenter() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = remember { getSettingsRepository() }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontViewModel.kt
@@ -12,7 +12,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.appearance.repository.ThemeRep
 import com.livefast.eattrash.raccoonforlemmy.core.appearance.theme.ColorSchemeProvider
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.DefaultMviModelDelegate
 import com.livefast.eattrash.raccoonforlemmy.core.architecture.MviModelDelegate
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.SettingsModel
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.AccountRepository
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.repository.SettingsRepository
@@ -30,7 +29,6 @@ class SettingsColorAndFontViewModel(
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
     private val accountRepository: AccountRepository,
-    private val notificationCenter: NotificationCenter,
 ) : ViewModel(),
     MviModelDelegate<Intent, UiState, Effect> by DefaultMviModelDelegate(initialState = UiState()),
     SettingsColorAndFontMviModel {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/di/SettingsTabModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/di/SettingsTabModule.kt
@@ -34,7 +34,6 @@ val settingsTabModule =
                 identityRepository = instance(),
                 settingsRepository = instance(),
                 accountRepository = instance(),
-                notificationCenter = instance(),
             )
         }
         bindViewModel {

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,6 +25,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.ThumbsUpDown
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -46,7 +46,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.PredictiveBackHandler
@@ -199,6 +198,20 @@ fun AccountSettingsScreen(modifier: Modifier = Modifier) {
                     )
                 },
             )
+        },
+        bottomBar = {
+            BottomAppBar {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    enabled = uiState.hasUnsavedChanges,
+                    onClick = {
+                        model.reduce(AccountSettingsMviModel.Intent.Submit)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.actionSave)
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
         },
         snackbarHost = {
             SnackbarHost(snackbarHostState) { data ->
@@ -436,20 +449,6 @@ fun AccountSettingsScreen(modifier: Modifier = Modifier) {
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.m))
-            }
-
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Button(
-                    enabled = uiState.hasUnsavedChanges,
-                    onClick = {
-                        model.reduce(AccountSettingsMviModel.Intent.Submit)
-                    },
-                ) {
-                    Text(text = LocalStrings.current.actionSave)
-                }
             }
         }
     }

--- a/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
+++ b/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
@@ -50,7 +50,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.toInt
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.toReadableName
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.unit.configurenavbar.composable.ConfigureAddAction
 import com.livefast.eattrash.raccoonforlemmy.unit.configurenavbar.composable.ConfigureNavBarItem
@@ -63,7 +62,6 @@ fun ConfigureNavBarScreen(modifier: Modifier = Modifier) {
     val model: ConfigureNavBarMviModel = getViewModel<ConfigureNavBarViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val notificationCenter = remember { getNotificationCenter() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = remember { getSettingsRepository() }

--- a/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
+++ b/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
@@ -2,9 +2,9 @@ package com.livefast.eattrash.raccoonforlemmy.unit.configurenavbar
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -33,7 +34,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.PredictiveBackHandler
@@ -134,6 +134,20 @@ fun ConfigureNavBarScreen(modifier: Modifier = Modifier) {
                 },
             )
         },
+        bottomBar = {
+            BottomAppBar {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    enabled = uiState.hasUnsavedChanges,
+                    onClick = {
+                        model.reduce(ConfigureNavBarMviModel.Intent.Save)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.actionSave)
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        },
     ) { padding ->
         Column(
             modifier =
@@ -207,20 +221,6 @@ fun ConfigureNavBarScreen(modifier: Modifier = Modifier) {
                             },
                         )
                     }
-                }
-            }
-
-            Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.m),
-                contentAlignment = Alignment.Center,
-            ) {
-                Button(
-                    enabled = uiState.hasUnsavedChanges,
-                    onClick = {
-                        model.reduce(ConfigureNavBarMviModel.Intent.Save)
-                    },
-                ) {
-                    Text(text = LocalStrings.current.actionSave)
                 }
             }
         }

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -52,7 +52,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBot
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipeDirection
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipeTarget
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.toIcon
@@ -74,7 +73,6 @@ fun ConfigureSwipeActionsScreen(modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
-    val notificationCenter = remember { getNotificationCenter() }
     var selectActionBottomSheet by remember { mutableStateOf<ActionConfig?>(null) }
 
     Scaffold(

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -91,7 +91,6 @@ fun EditCommunityScreen(modifier: Modifier = Modifier, communityId: Long? = null
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val scrollState = rememberScrollState()
     val themeRepository = remember { getThemeRepository() }
-    val notificationCenter = remember { getNotificationCenter() }
     val contentFontFamily by themeRepository.contentFontFamily.collectAsState()
     val contentTypography = contentFontFamily.toTypography()
     val settingsRepository = remember { getSettingsRepository() }

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.InfiniteRepeatableSpec
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -24,6 +23,7 @@ import androidx.compose.material.icons.filled.SettingsApplications
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.TextFormat
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -44,7 +44,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.PredictiveBackHandler
@@ -70,7 +69,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.EditFormattedI
 import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.EditTextualInfoDialog
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.di.getGalleryHelper
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.CommunityVisibilityType
@@ -196,6 +194,20 @@ fun EditCommunityScreen(modifier: Modifier = Modifier, communityId: Long? = null
                     )
                 },
             )
+        },
+        bottomBar = {
+            BottomAppBar {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    enabled = uiState.hasUnsavedChanges,
+                    onClick = {
+                        model.reduce(EditCommunityMviModel.Intent.Submit)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.actionSave)
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
         },
         snackbarHost = {
             SnackbarHost(snackbarHostState) { data ->
@@ -330,20 +342,6 @@ fun EditCommunityScreen(modifier: Modifier = Modifier, communityId: Long? = null
                 )
 
                 Spacer(modifier = Modifier.height(Spacing.m))
-            }
-
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Button(
-                    enabled = uiState.hasUnsavedChanges,
-                    onClick = {
-                        model.reduce(EditCommunityMviModel.Intent.Submit)
-                    },
-                ) {
-                    Text(text = LocalStrings.current.actionSave)
-                }
             }
         }
     }

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -74,7 +74,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.data.ActionOnSwipe
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.VoteAction
@@ -113,7 +112,6 @@ fun FilteredContentsScreen(
     val settingsRepository = remember { getSettingsRepository() }
     val settings by settingsRepository.currentSettings.collectAsState()
     val mainRouter = remember { getMainRouter() }
-    val notificationCenter = remember { getNotificationCenter() }
     var rawContent by remember { mutableStateOf<Any?>(null) }
     val themeRepository = remember { getThemeRepository() }
     val upVoteColor by themeRepository.upVoteColor.collectAsState()

--- a/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
+++ b/unit/instanceinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/instanceinfo/InstanceInfoScreen.kt
@@ -41,7 +41,6 @@ import com.livefast.eattrash.raccoonforlemmy.core.commonui.modals.SortBottomShee
 import com.livefast.eattrash.raccoonforlemmy.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforlemmy.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforlemmy.core.notifications.di.getNotificationCenter
 import com.livefast.eattrash.raccoonforlemmy.core.persistence.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforlemmy.core.utils.compose.onClick
 import com.livefast.eattrash.raccoonforlemmy.domain.lemmy.data.getAdditionalLabel
@@ -62,7 +61,6 @@ fun InstanceInfoScreen(url: String, modifier: Modifier = Modifier) {
     val settings by settingsRepository.currentSettings.collectAsState()
     val listState = rememberLazyListState()
     val mainRouter = remember { getMainRouter() }
-    val notificationCenter = remember { getNotificationCenter() }
     var sortBottomSheetOpened by remember { mutableStateOf(false) }
     val instanceName = url.replace("https://", "")
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR moves all the "submit" buttons in the `bottomBar` slot of Material 3 `Scaffold`s in order to have automatic management of navigation insets.

Affected screens:
- web preferences (remote account settings)
- community edit
- configure bottom navigation bar
