### PR TITLE
Update gradle so compose.ui:ui-backhandler stops issuing errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle
-org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx6096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 #Kotlin
 kotlin.code.style=official
 #Android
@@ -13,3 +13,5 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 #Native
 kotlin.native.ignoreDisabledTargets=true
 kotlin.native.cacheKind=none
+
+org.gradle.configuration-cache=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ calf = "0.9.0"
 coil = "3.3.0"
 colorpicker = "1.1.2"
 compose = "1.9.0"
+compose-ui-backhandler = "1.10.3"
 compose-multiplatform-media-player = "1.0.47"
 kodein = "7.29.0"
 kotlin = "2.2.21"
@@ -62,6 +63,7 @@ compose-multiplatform-media-player = { module = "network.chaintech:compose-multi
 compose-gradlePlugin = { module = "org.jetbrains.compose:org.jetbrains.compose.gradle.plugin", version.ref = "compose" }
 compose-colorpicker = { module = "com.github.skydoves:colorpicker-compose", version.ref = "colorpicker" }
 compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler" }
+#compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-ui-backhandler" }
 
 gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -86,6 +86,7 @@ kotlin {
                 api(projects.feature.search)
                 api(projects.feature.profile)
                 api(projects.feature.settings)
+//                implementation(libs.compose.ui.backhandler)
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
## Technical details
This PR addresses the gradle sync errors around `ui-backhandler `. Interesting enough, these errors do NOT prevent the app from building properly.

It also increases slightly the size of the gradle daemon and make it use configuration cache, so it provides an improved experience during development.

### Error details
```
KMP Dependencies Resolution Failure
Source set 'commonMain' couldn't resolve dependencies for all target platforms
Couldn't resolve dependency 'org.jetbrains.compose.ui:ui-backhandler' in 'commonMain' for all target platforms.
The dependency should target platforms: [android, android, iosArm64, iosSimulatorArm64, iosX64]
Unresolved platforms: [android, android]
```
<img width="1255" height="551" alt="image" src="https://github.com/user-attachments/assets/2e4575f1-3496-438d-9c1b-6d579ba3150d" />

## Additional notes

The library mentioned is now obsolete, so we get a few warnings while compiling, advising the code to migrate from `ui-backhandler ` to `navigationevent-compose`

See more on https://stackoverflow.com/questions/79340066/backhandler-on-compose-multiplatform-android-and-ios.
