### PR TITLE
Fix/navigation can pop

### DIFF
--- a/core/navigation/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
@@ -58,7 +59,7 @@ class DefaultNavigationCoordinatorTest {
         assertFalse(initial)
         val navigator =
             mockk<NavigationAdapter> {
-                every { canPop } returns true
+                every { canPop } returns MutableStateFlow(true)
             }
 
         sut.setRootNavigator(navigator)
@@ -113,7 +114,7 @@ class DefaultNavigationCoordinatorTest {
         val destination = Destination.WebInternal(url = "www.example.com")
         val navigator =
             mockk<NavigationAdapter>(relaxUnitFun = true) {
-                every { canPop } returns true
+                every { canPop } returns MutableStateFlow(true)
             }
         sut.setRootNavigator(navigator)
 
@@ -133,7 +134,7 @@ class DefaultNavigationCoordinatorTest {
     fun whenPopScreen_thenInteractionsAreAsExpected() = runTest {
         val navigator =
             mockk<NavigationAdapter>(relaxUnitFun = true) {
-                every { canPop } returns false
+                every { canPop } returns MutableStateFlow(false)
             }
         sut.setRootNavigator(navigator)
 
@@ -225,7 +226,7 @@ class DefaultNavigationCoordinatorTest {
     fun whenPopUntilRoot_thenInteractionsAreAsExpected() = runTest {
         val navigator =
             mockk<NavigationAdapter>(relaxUnitFun = true) {
-                every { canPop } returns false
+                every { canPop } returns MutableStateFlow(false)
             }
         sut.setRootNavigator(navigator)
 

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationAdapter.kt
@@ -7,6 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -15,16 +19,22 @@ class DefaultNavigationAdapter(
     private val navController: NavController,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : NavigationAdapter {
-    override val canPop: Boolean get() = navController.currentBackStack.value.size > 1
+    override val canPop = MutableStateFlow(false)
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private var job: Job? = null
+
+    init {
+        navController.currentBackStack
+            .onEach { backStack -> canPop.update { backStack.size > 2 } }
+            .launchIn(scope)
+    }
 
     override fun navigate(destination: Destination, replaceTop: Boolean) {
         if (job?.isActive == true) {
             return
         }
         perform {
-            if (replaceTop && canPop) {
+            if (replaceTop && canPop.value) {
                 navController.popBackStack()
             }
             navController.navigate(destination)
@@ -36,7 +46,7 @@ class DefaultNavigationAdapter(
             return
         }
         perform {
-            if (canPop) {
+            if (canPop.value) {
                 navController.popBackStack()
             }
         }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -5,12 +5,15 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
@@ -32,6 +35,7 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     private var rootNavController: NavigationAdapter? = null
     private var bottomNavController: BottomNavigationAdapter? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var updateCanPopJob: Job? = null
 
     companion object {
         private const val DEEP_LINK_DELAY = 500L
@@ -39,7 +43,10 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun setRootNavigator(adapter: NavigationAdapter) {
         rootNavController = adapter
-        refreshCanPop()
+        updateCanPopJob?.cancel()
+        updateCanPopJob = adapter.canPop.onEach { newValue ->
+            canPop.update { newValue }
+        }.launchIn(scope)
     }
 
     override fun setBottomBarScrollConnection(value: NestedScrollConnection?) {
@@ -91,12 +98,10 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     override fun push(destination: Destination) {
         closeSideMenu()
         rootNavController?.navigate(destination)
-        refreshCanPop()
     }
 
     override fun pop() {
         rootNavController?.pop()
-        refreshCanPop()
     }
 
     override fun setExitMessageVisible(value: Boolean) {
@@ -130,11 +135,5 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun popUntilRoot() {
         rootNavController?.popUntilRoot()
-    }
-
-    private fun refreshCanPop() {
-        canPop.update {
-            rootNavController?.canPop ?: false
-        }
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/NavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/NavigationAdapter.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforlemmy.core.navigation
 
+import kotlinx.coroutines.flow.StateFlow
+
 interface NavigationAdapter {
-    val canPop: Boolean
+    val canPop: StateFlow<Boolean>
 
     fun navigate(destination: Destination, replaceTop: Boolean = false)
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/advanced/AdvancedSettingsScreen.kt
@@ -81,6 +81,7 @@ fun AdvancedSettingsScreen(modifier: Modifier = Modifier) {
     val model: AdvancedSettingsMviModel = getViewModel<AdvancedSettingsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
@@ -134,7 +135,7 @@ fun AdvancedSettingsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/colors/SettingsColorAndFontScreen.kt
@@ -86,6 +86,7 @@ fun SettingsColorAndFontScreen(modifier: Modifier = Modifier) {
     val model: SettingsColorAndFontMviModel = getViewModel<SettingsColorAndFontViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = rememberSettingsRepository()
@@ -138,7 +139,7 @@ fun SettingsColorAndFontScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/feature/settings/main/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val drawerCoordinator = rememberDrawerCoordinator()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     var infoDialogOpened by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -89,7 +90,7 @@ fun SettingsScreen(
                 windowInsets = topAppBarState.toWindowInsets(),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
+++ b/unit/accountsettings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/accountsettings/AccountSettingsScreen.kt
@@ -86,6 +86,7 @@ fun AccountSettingsScreen(modifier: Modifier = Modifier) {
     val model: AccountSettingsMviModel = getViewModel<AccountSettingsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val scrollState = rememberScrollState()
@@ -155,7 +156,7 @@ fun AccountSettingsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (uiState.hasUnsavedChanges) {

--- a/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
+++ b/unit/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/acknowledgements/main/AcknowledgementsScreen.kt
@@ -42,6 +42,7 @@ fun AcknowledgementsScreen(modifier: Modifier = Modifier) {
     val model: AcknowledgementsMviModel = getViewModel<AcknowledgementsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -61,7 +62,7 @@ fun AcknowledgementsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
+++ b/unit/communitydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/communitydetail/CommunityDetailScreen.kt
@@ -133,6 +133,7 @@ fun CommunityDetailScreen(communityId: Long, modifier: Modifier = Modifier, othe
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val themeRepository = rememberThemeRepository()
     val upVoteColor by themeRepository.upVoteColor.collectAsState()
     val downVoteColor by themeRepository.downVoteColor.collectAsState()
@@ -545,7 +546,7 @@ fun CommunityDetailScreen(communityId: Long, modifier: Modifier = Modifier, othe
                     }
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
+++ b/unit/configurecontentview/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurecontentview/ConfigureContentViewScreen.kt
@@ -57,6 +57,7 @@ fun ConfigureContentViewScreen(modifier: Modifier = Modifier) {
     val model: ConfigureContentViewMviModel = getViewModel<ConfigureContentViewViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val scrollState = rememberScrollState()
@@ -81,7 +82,7 @@ fun ConfigureContentViewScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
+++ b/unit/configurenavbar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configurenavbar/ConfigureNavBarScreen.kt
@@ -63,6 +63,7 @@ fun ConfigureNavBarScreen(modifier: Modifier = Modifier) {
     val model: ConfigureNavBarMviModel = getViewModel<ConfigureNavBarViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = rememberSettingsRepository()
@@ -104,7 +105,7 @@ fun ConfigureNavBarScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (uiState.hasUnsavedChanges) {

--- a/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
+++ b/unit/configureswipeactions/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/configureswipeactions/ConfigureSwipeActionsScreen.kt
@@ -61,6 +61,7 @@ fun ConfigureSwipeActionsScreen(modifier: Modifier = Modifier) {
     val model: ConfigureSwipeActionsMviModel = getViewModel<ConfigureSwipeActionsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val settingsRepository = rememberSettingsRepository()
@@ -82,7 +83,7 @@ fun ConfigureSwipeActionsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
+++ b/unit/editcommunity/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/editcommunity/EditCommunityScreen.kt
@@ -81,6 +81,7 @@ fun EditCommunityScreen(modifier: Modifier = Modifier, communityId: Long? = null
         getViewModel<EditCommunityViewModel>(EditCommunityMviModelParams(communityId ?: 0))
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val scrollState = rememberScrollState()
@@ -151,7 +152,7 @@ fun EditCommunityScreen(modifier: Modifier = Modifier, communityId: Long? = null
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (uiState.hasUnsavedChanges) {

--- a/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
+++ b/unit/filteredcontents/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/filteredcontents/FilteredContentsScreen.kt
@@ -119,8 +119,8 @@ fun FilteredContentsScreen(
     val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
-    val navigationCanPop by navigationCoordinator.canPop.collectAsState()
-    val isTopLevel = !navigationCanPop
+    val canPopState by navigationCoordinator.canPop.collectAsState()
+    val isTopLevel = !canPopState
     val connection =
         if (isTopLevel) {
             navigationCoordinator.getBottomBarScrollConnection()
@@ -171,7 +171,7 @@ fun FilteredContentsScreen(
                 windowInsets = topAppBarState.toWindowInsets(),
                 scrollBehavior = scrollBehavior,
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
+++ b/unit/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/licences/LicencesScreen.kt
@@ -39,6 +39,7 @@ fun LicencesScreen(modifier: Modifier = Modifier) {
     val model: LicencesMviModel = getViewModel<LicencesViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -58,7 +59,7 @@ fun LicencesScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
+++ b/unit/manageban/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/manageban/ManageBanScreen.kt
@@ -70,6 +70,7 @@ fun ManageBanScreen(modifier: Modifier = Modifier) {
     val model: ManageBanMviModel = getViewModel<ManageBanViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
@@ -132,7 +133,7 @@ fun ManageBanScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
+++ b/unit/postdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/postdetail/PostDetailScreen.kt
@@ -149,6 +149,7 @@ fun PostDetailScreen(
     val otherInstanceName = remember { otherInstance }
     val commentIdToHighlight = remember { highlightCommentId }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
@@ -573,7 +574,7 @@ fun PostDetailScreen(
                     }
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
+++ b/unit/userdetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/unit/userdetail/UserDetailScreen.kt
@@ -135,6 +135,7 @@ fun UserDetailScreen(userId: Long, modifier: Modifier = Modifier, otherInstance:
     val defaultSaveColor = MaterialTheme.colorScheme.secondaryContainer
     val defaultDownVoteColor = MaterialTheme.colorScheme.tertiary
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     var rawContent by remember { mutableStateOf<Any?>(null) }
     val settingsRepository = rememberSettingsRepository()
     val settings by settingsRepository.currentSettings.collectAsState()
@@ -368,7 +369,7 @@ fun UserDetailScreen(userId: Long, modifier: Modifier = Modifier, otherInstance:
                     }
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes  -->
This PR fixes a bug in the interaction between the `NavigationAdapter` used for Compose Navigation and `NavigationCoordinator` to automatically observe backstack changes, eliminating the need for manual state refreshes after navigation events.

Moreover, instead of using the state flow value directly, whenever canPop was read in the UI layer it is consistently converted to Compose state to make sure the UI always reacts to its updates.

Twin PR:
https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/1188
