### PR TITLE
fix: bottom navigation section state update

### DIFF
--- a/core/navigation/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -16,7 +16,6 @@ import org.junit.Rule
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,22 +30,30 @@ class DefaultNavigationCoordinatorTest {
 
     @Test
     fun whenSetBottomNavigationSection_thenValueIsUpdated() = runTest {
-        val initial = sut.currentSection.value
-        assertNull(initial)
+        val navigator =
+            mockk<BottomNavigationAdapter>(relaxUnitFun = true) {
+                every { currentSection } returns MutableStateFlow(TabNavigationSection.Home)
+            }
+        sut.setBottomNavigator(navigator)
 
         sut.setBottomNavigationSection(TabNavigationSection.Profile)
 
-        val value = sut.currentSection.value
-        assertEquals(TabNavigationSection.Profile, value)
+        verify { navigator.navigate(TabNavigationSection.Profile) }
     }
 
     @Test
     fun whenSetBottomNavigationSectionTwice_thenOnDoubleTabSelectionTriggered() = runTest {
-        sut.setBottomNavigationSection(TabNavigationSection.Profile)
+        val navigator =
+            mockk<BottomNavigationAdapter>(relaxUnitFun = true) {
+                every { currentSection } returns MutableStateFlow(TabNavigationSection.Profile)
+            }
+        sut.setBottomNavigator(navigator)
+
         launch {
             delay(DELAY)
             sut.setBottomNavigationSection(TabNavigationSection.Profile)
         }
+
         sut.onDoubleTabSelection.test {
             val section = awaitItem()
             assertEquals(TabNavigationSection.Profile, section)
@@ -95,18 +102,6 @@ class DefaultNavigationCoordinatorTest {
         sut.setExitMessageVisible(true)
         val value = sut.exitMessageVisible.value
         assertTrue(value)
-    }
-
-    @Test
-    fun whenSetBottomNavigationSection_thenAdapterNavigatesToSection() = runTest {
-        val adapter = mockk<BottomNavigationAdapter>(relaxUnitFun = true)
-        sut.setBottomNavigator(adapter)
-
-        sut.setBottomNavigationSection(TabNavigationSection.Home)
-
-        verify {
-            adapter.navigate(TabNavigationSection.Home)
-        }
     }
 
     @Test

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/BottomNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/BottomNavigationAdapter.kt
@@ -1,13 +1,8 @@
 package com.livefast.eattrash.raccoonforlemmy.core.navigation
 
-import androidx.navigation.NavController
+import kotlinx.coroutines.flow.StateFlow
 
 interface BottomNavigationAdapter {
+    val currentSection: StateFlow<TabNavigationSection?>
     fun navigate(section: TabNavigationSection)
-}
-
-class DefaultBottomNavigationAdapter(private val navController: NavController) : BottomNavigationAdapter {
-    override fun navigate(section: TabNavigationSection) {
-        navController.navigate(section)
-    }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultBottomNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultBottomNavigationAdapter.kt
@@ -1,0 +1,42 @@
+package com.livefast.eattrash.raccoonforlemmy.core.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hasRoute
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+class DefaultBottomNavigationAdapter(
+    private val navController: NavController,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : BottomNavigationAdapter {
+    override val currentSection = MutableStateFlow<TabNavigationSection?>(null)
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    init {
+        navController.currentBackStackEntryFlow.onEach { entry ->
+            val destination = entry.destination
+            currentSection.update { old ->
+                when {
+                    destination.hasRoute<TabNavigationSection.Bookmarks>() -> TabNavigationSection.Bookmarks
+                    destination.hasRoute<TabNavigationSection.Explore>() -> TabNavigationSection.Explore
+                    destination.hasRoute<TabNavigationSection.Home>() -> TabNavigationSection.Home
+                    destination.hasRoute<TabNavigationSection.Inbox>() -> TabNavigationSection.Inbox
+                    destination.hasRoute<TabNavigationSection.Profile>() -> TabNavigationSection.Profile
+                    destination.hasRoute<TabNavigationSection.Settings>() -> TabNavigationSection.Settings
+                    else -> TabNavigationSection.Home
+                }
+            }
+        }.launchIn(scope)
+    }
+
+    override fun navigate(section: TabNavigationSection) {
+        navController.navigate(section)
+    }
+}

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/navigation/DefaultNavigationCoordinator.kt
@@ -35,6 +35,7 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     private var rootNavController: NavigationAdapter? = null
     private var bottomNavController: BottomNavigationAdapter? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var updateBottomNavigationSection: Job? = null
     private var updateCanPopJob: Job? = null
 
     companion object {
@@ -57,6 +58,10 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun setBottomNavigator(adapter: BottomNavigationAdapter) {
         bottomNavController = adapter
+        updateBottomNavigationSection?.cancel()
+        updateBottomNavigationSection = adapter.currentSection.onEach { newValue ->
+            currentSection.update { newValue }
+        }.launchIn(scope)
     }
 
     override fun setBottomNavigationSection(section: TabNavigationSection) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR eliminates the manual state management for the current bottom navigation section in `DefaultNavigationCoordinator`, introducing an observable `StateFlow` in `BottomNavigationAdapter` and mapping directly that.

This fixes a bug due to which, when hitting the back button in the main screen, the bottom navigation state changed but the currently selected in the bottom navigation bar remained out of sync.

## Additional notes
<!-- Anything to declare for code review? -->
Twin PR: https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/1189
